### PR TITLE
Make rules updates atomic instead of delete-and-create

### DIFF
--- a/docs/resources/workshop_file_access_rule.md
+++ b/docs/resources/workshop_file_access_rule.md
@@ -5,6 +5,14 @@ subcategory: ""
 description: |-
   The nps_workshop_file_access_rule resource manages File Access Rules.
   Management of file access rules requires the read:rules and write:rules permissions.
+  Updates to non-key fields are applied atomically in place. Changing the rule's natural key (name or tag) forces the rule to be replaced: by default Terraform destroys the old rule before creating the new one, leaving a brief window with no rule in place. To avoid that window, add a create_before_destroy lifecycle block:
+  
+  resource "nps_workshop_file_access_rule" "example" {
+    # ...
+    lifecycle {
+      create_before_destroy = true
+    }
+  }
 ---
 
 # nps_workshop_file_access_rule (Resource)
@@ -12,6 +20,17 @@ description: |-
 The `nps_workshop_file_access_rule` resource manages File Access Rules.
 
 Management of file access rules requires the `read:rules` and `write:rules` permissions.
+
+Updates to non-key fields are applied atomically in place. Changing the rule's natural key (`name` or `tag`) forces the rule to be replaced: by default Terraform destroys the old rule before creating the new one, leaving a brief window with no rule in place. To avoid that window, add a `create_before_destroy` lifecycle block:
+
+```hcl
+resource "nps_workshop_file_access_rule" "example" {
+  # ...
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
 
 ## Example Usage
 

--- a/docs/resources/workshop_file_access_rule.md
+++ b/docs/resources/workshop_file_access_rule.md
@@ -81,7 +81,7 @@ resource "nps_workshop_file_access_rule" "ChromeCookies" {
 
 ### Read-Only
 
-- `id` (Number) The automatically generated ID of this file access rule
+- `id` (Number) The server-generated ID of this file access rule. This ID is reassigned on every upsert, including in-place updates, so it must not be relied on as a stable identifier across applies.
 
 ## Import
 

--- a/docs/resources/workshop_package_rule.md
+++ b/docs/resources/workshop_package_rule.md
@@ -56,4 +56,4 @@ resource "nps_workshop_package_rule" "example" {
 
 ### Read-Only
 
-- `id` (Number) The automatically generated ID of this package rule
+- `id` (Number) The server-generated ID of this package rule. This ID is reassigned on every upsert, including in-place updates, so it must not be relied on as a stable identifier across applies.

--- a/docs/resources/workshop_package_rule.md
+++ b/docs/resources/workshop_package_rule.md
@@ -6,6 +6,14 @@ description: |-
   The nps_workshop_package_rule resource manages Package Rules.
   Package rules sync identifiers from GAL for a package.
   Management of package rules requires the read:rules and write:rules permissions.
+  Updates to non-key fields (such as policy) are applied atomically in place. Changing the rule's natural key (tag, name, or source) forces the rule to be replaced: by default Terraform destroys the old rule before creating the new one, leaving a brief window with no rule in place. To avoid that window, add a create_before_destroy lifecycle block:
+  
+  resource "nps_workshop_package_rule" "example" {
+    # ...
+    lifecycle {
+      create_before_destroy = true
+    }
+  }
 ---
 
 # nps_workshop_package_rule (Resource)
@@ -15,6 +23,17 @@ The `nps_workshop_package_rule` resource manages Package Rules.
 Package rules sync identifiers from GAL for a package.
 
 Management of package rules requires the `read:rules` and `write:rules` permissions.
+
+Updates to non-key fields (such as `policy`) are applied atomically in place. Changing the rule's natural key (`tag`, `name`, or `source`) forces the rule to be replaced: by default Terraform destroys the old rule before creating the new one, leaving a brief window with no rule in place. To avoid that window, add a `create_before_destroy` lifecycle block:
+
+```hcl
+resource "nps_workshop_package_rule" "example" {
+  # ...
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
 
 
 

--- a/docs/resources/workshop_rule.md
+++ b/docs/resources/workshop_rule.md
@@ -5,6 +5,14 @@ subcategory: ""
 description: |-
   The nps_workshop_rule resource manages Rules.
   Management of rules requires the read:rules and write:rules permissions.
+  Updates to non-key fields (such as policy or comment) are applied atomically in place. Changing the rule's natural key (identifier, rule_type, or tag) forces the rule to be replaced: by default Terraform destroys the old rule before creating the new one, leaving a brief window with no rule in place. To avoid that window, add a create_before_destroy lifecycle block:
+  
+  resource "nps_workshop_rule" "example" {
+    # ...
+    lifecycle {
+      create_before_destroy = true
+    }
+  }
 ---
 
 # nps_workshop_rule (Resource)
@@ -12,6 +20,17 @@ description: |-
 The `nps_workshop_rule` resource manages Rules.
 
 Management of rules requires the `read:rules` and `write:rules` permissions.
+
+Updates to non-key fields (such as `policy` or `comment`) are applied atomically in place. Changing the rule's natural key (`identifier`, `rule_type`, or `tag`) forces the rule to be replaced: by default Terraform destroys the old rule before creating the new one, leaving a brief window with no rule in place. To avoid that window, add a `create_before_destroy` lifecycle block:
+
+```hcl
+resource "nps_workshop_rule" "example" {
+  # ...
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
 
 ## Example Usage
 

--- a/docs/resources/workshop_rule.md
+++ b/docs/resources/workshop_rule.md
@@ -53,7 +53,7 @@ resource "nps_workshop_rule" "yes" {
 ### Optional
 
 - `affected_host_threshold` (Block, Optional) If set, the server will count how many hosts (matching the rule's tag) have run a binary covered by this rule's `identifier` and `rule_type` within the lookback window. If the count is greater than or equal to `host_count`, the rule is not created and a `FailedPrecondition` error is returned. The check applies the same identifier match used for resolution; for `CEL`/`SEATBELT` rules the count reflects the underlying identifier and may overstate the true impact. **Note:** this block is only supported in Workshop 2025.5 and later; in earlier versions it will be ignored by the server. (see [below for nested schema](#nestedblock--affected_host_threshold))
-- `block_reason` (String) The block reason for this rule. The possible values are: `POLICY`, and `MALICIOUS`.
+- `block_reason` (String) The block reason for this rule. The possible values are: `BLOCK_REASON_POLICY`, and `BLOCK_REASON_MALICIOUS`.
 - `cel_expr` (String) A CEL expression to evaluate when this rule matches. Only valid when the policy is set to `CEL`.
 - `comment` (String) A comment to add to this rule. Will be displayed in the Workshop UI.
 - `custom_msg` (String) A custom message to display to the user when this rule causes Santa to block the execution.

--- a/docs/resources/workshop_rule.md
+++ b/docs/resources/workshop_rule.md
@@ -72,7 +72,7 @@ resource "nps_workshop_rule" "yes" {
 ### Optional
 
 - `affected_host_threshold` (Block, Optional) If set, the server will count how many hosts (matching the rule's tag) have run a binary covered by this rule's `identifier` and `rule_type` within the lookback window. If the count is greater than or equal to `host_count`, the rule is not created and a `FailedPrecondition` error is returned. The check applies the same identifier match used for resolution; for `CEL`/`SEATBELT` rules the count reflects the underlying identifier and may overstate the true impact. **Note:** this block is only supported in Workshop 2025.5 and later; in earlier versions it will be ignored by the server. (see [below for nested schema](#nestedblock--affected_host_threshold))
-- `block_reason` (String) The block reason for this rule. The possible values are: `BLOCK_REASON_POLICY`, and `BLOCK_REASON_MALICIOUS`.
+- `block_reason` (String) The block reason for this rule. Valid values are `BLOCK_REASON_POLICY` and `BLOCK_REASON_MALICIOUS`. For blocklist-family policies an unset value defaults to `BLOCK_REASON_POLICY`; leave it unset for non-blocklist policies, which cannot have a block reason.
 - `cel_expr` (String) A CEL expression to evaluate when this rule matches. Only valid when the policy is set to `CEL`.
 - `comment` (String) A comment to add to this rule. Will be displayed in the Workshop UI.
 - `custom_msg` (String) A custom message to display to the user when this rule causes Santa to block the execution.
@@ -80,7 +80,7 @@ resource "nps_workshop_rule" "yes" {
 
 ### Read-Only
 
-- `id` (String) The automatically generated ID of this rule
+- `id` (String) The server-generated ID of this rule. This ID is reassigned on every upsert, including in-place updates, so it must not be relied on as a stable identifier across applies.
 
 <a id="nestedblock--affected_host_threshold"></a>
 ### Nested Schema for `affected_host_threshold`

--- a/internal/provider/resource_file_access_rule.go
+++ b/internal/provider/resource_file_access_rule.go
@@ -252,7 +252,7 @@ func (r *FileAccessRuleResource) Schema(ctx context.Context, req resource.Schema
 			// whenever the rule changes.
 			"id": schema.Int64Attribute{
 				Computed:            true,
-				MarkdownDescription: "The automatically generated ID of this file access rule",
+				MarkdownDescription: "The server-generated ID of this file access rule. This ID is reassigned on every upsert, including in-place updates, so it must not be relied on as a stable identifier across applies.",
 			},
 		},
 	}

--- a/internal/provider/resource_file_access_rule.go
+++ b/internal/provider/resource_file_access_rule.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -93,8 +95,8 @@ func (r *FileAccessRuleResource) Metadata(ctx context.Context, req resource.Meta
 
 func (r *FileAccessRuleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "The nps_workshop_file_access_rule resource manages File Access Rules. Management of file access rules requires the read:rules and write:rules permissions.",
-		MarkdownDescription: "The `nps_workshop_file_access_rule` resource manages File Access Rules.\n\nManagement of file access rules requires the `read:rules` and `write:rules` permissions.",
+		Description:         "The nps_workshop_file_access_rule resource manages File Access Rules. Management of file access rules requires the read:rules and write:rules permissions. Changing name or tag forces replacement; add a create_before_destroy lifecycle block to avoid a window where the rule does not exist.",
+		MarkdownDescription: "The `nps_workshop_file_access_rule` resource manages File Access Rules.\n\nManagement of file access rules requires the `read:rules` and `write:rules` permissions.\n\nUpdates to non-key fields are applied atomically in place. Changing the rule's natural key (`name` or `tag`) forces the rule to be replaced: by default Terraform destroys the old rule before creating the new one, leaving a brief window with no rule in place. To avoid that window, add a `create_before_destroy` lifecycle block:\n\n```hcl\nresource \"nps_workshop_file_access_rule\" \"example\" {\n  # ...\n  lifecycle {\n    create_before_destroy = true\n  }\n}\n```",
 
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
@@ -102,12 +104,22 @@ func (r *FileAccessRuleResource) Schema(ctx context.Context, req resource.Schema
 				MarkdownDescription: "The name for this file access rule. Rule names are unique per-tag.",
 				Required:            true,
 				Validators:          []validator.String{},
+				// Part of the natural key (tag, name). The upsert only supersedes the
+				// old rule when the key matches, so changing the key must replace
+				// rather than update in place.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"tag": schema.StringAttribute{
 				Description:         "The tag for this file access rule. The tag determines which hosts this rule will apply to. The tag must already exist in Workshop.",
 				MarkdownDescription: "The tag for this file access rule. The tag determines which hosts this rule will apply to. The tag must already exist in Workshop.",
 				Required:            true,
 				// TODO(rah): Add validator
+				// Part of the natural key; see name.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"allow_read_access": schema.BoolAttribute{
 				Description:         "Whether to allow read access for files matching this rule.",
@@ -423,14 +435,13 @@ func buildFileAccessRule(ctx context.Context, data FileAccessRuleResourceModel, 
 }
 
 func (r *FileAccessRuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state FileAccessRuleResourceModel
+	var plan FileAccessRuleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	newID, diags := r.upsertFileAccessRule(ctx, plan, state)
+	newID, diags := r.upsertFileAccessRule(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if newID.IsNull() {
 		return
@@ -443,12 +454,13 @@ func (r *FileAccessRuleResource) Update(ctx context.Context, req resource.Update
 }
 
 // upsertFileAccessRule performs an atomic update via the CreateFileAccessRule
-// upsert RPC (keyed on (tag, name)) and returns the new rule ID. A matching
-// rule is atomically superseded, so a failed update leaves the old rule in
-// place. When the key changed, the upsert created a distinct new rule and left
-// the old one active, so we delete the old rule afterwards (a failed cleanup is
-// a warning, not an error). Returns a null ID (with diagnostics) on failure.
-func (r *FileAccessRuleResource) upsertFileAccessRule(ctx context.Context, plan, state FileAccessRuleResourceModel) (types.Int64, diag.Diagnostics) {
+// upsert RPC (keyed on (tag, name)) and returns the new rule ID. The server
+// supersedes the existing rule sharing this key and returns a new ID, so the
+// update is atomic and a failure leaves the old rule in place. The key
+// attributes are RequiresReplace, so Update only ever changes non-key fields
+// where the server is guaranteed to supersede; we never delete the old rule
+// ourselves. Returns a null ID (with diagnostics) on failure.
+func (r *FileAccessRuleResource) upsertFileAccessRule(ctx context.Context, plan FileAccessRuleResourceModel) (types.Int64, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	rule := buildFileAccessRule(ctx, plan, &diags)
@@ -463,21 +475,7 @@ func (r *FileAccessRuleResource) upsertFileAccessRule(ctx context.Context, plan,
 		diags.AddError("Client Error", fmt.Sprintf("Failed to update file access rule: %v", err))
 		return types.Int64Null(), diags
 	}
-	newID := types.Int64Value(crResp.GetRuleId())
-
-	keyChanged := !plan.Tag.Equal(state.Tag) || !plan.Name.Equal(state.Name)
-	if keyChanged && !state.Id.IsNull() {
-		if _, err := r.client.DeleteFileAccessRule(ctx, apipb.DeleteFileAccessRuleRequest_builder{
-			RuleId: proto.Int64(state.Id.ValueInt64()),
-		}.Build()); err != nil {
-			diags.AddWarning(
-				"Failed to delete superseded file access rule",
-				fmt.Sprintf("The updated rule was created (ID %d), but deleting the old rule (ID %d) failed: %v. You may need to delete it manually.",
-					newID.ValueInt64(), state.Id.ValueInt64(), err),
-			)
-		}
-	}
-	return newID, diags
+	return types.Int64Value(crResp.GetRuleId()), diags
 }
 
 func (r *FileAccessRuleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_file_access_rule.go
+++ b/internal/provider/resource_file_access_rule.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -15,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -87,6 +86,9 @@ type FileAccessRuleResourceModel struct {
 
 func (r *FileAccessRuleResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_workshop_file_access_rule"
+	// The rule ID (used as the identity) changes on every upsert, including
+	// in-place updates, so the identity is mutable across the resource's life.
+	resp.ResourceBehavior.MutableIdentity = true
 }
 
 func (r *FileAccessRuleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -232,13 +234,13 @@ func (r *FileAccessRuleResource) Schema(ctx context.Context, req resource.Schema
 				},
 			},
 
-			// Computed value, returned from Create
+			// Computed value, returned from Create. The ID changes on every
+			// upsert (including in-place updates), so it is intentionally left
+			// without UseStateForUnknown: it plans as "known after apply"
+			// whenever the rule changes.
 			"id": schema.Int64Attribute{
 				Computed:            true,
 				MarkdownDescription: "The automatically generated ID of this file access rule",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 		},
 	}
@@ -271,54 +273,13 @@ func (r *FileAccessRuleResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	// Convert rule type string to enum
-	ruleType := apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_UNSPECIFIED
-	switch data.RuleType.ValueString() {
-	case "PathsWithAllowedProcesses":
-		ruleType = apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_PATHS_WITH_ALLOWED_PROCESSES
-	case "PathsWithDeniedProcesses":
-		ruleType = apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_PATHS_WITH_DENIED_PROCESSES
-	case "ProcessesWithAllowedPaths":
-		ruleType = apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_PROCESSES_WITH_ALLOWED_PATHS
-	case "ProcessesWithDeniedPaths":
-		ruleType = apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_PROCESSES_WITH_DENIED_PATHS
-	}
-
-	// Build the file access rule
-	builder := apipb.FileAccessRule_builder{
-		Tag:                 data.Tag.ValueString(),
-		Name:                data.Name.ValueString(),
-		AllowReadAccess:     data.AllowReadAccess.ValueBool(),
-		BlockViolations:     data.BlockViolations.ValueBool(),
-		RuleType:            ruleType,
-		EnableSilentMode:    data.EnableSilentMode.ValueBool(),
-		EnableSilentTtyMode: data.EnableSilentTtyMode.ValueBool(),
-		BlockMessage:        data.BlockMessage.ValueString(),
-		EventDetailUrl:      data.EventDetailUrl.ValueString(),
-		EventDetailText:     data.EventDetailText.ValueString(),
-	}
-
-	// Convert list attributes to string slices
-	convertListHelper := func(v types.List, target *[]string) {
-		if v.IsNull() || v.IsUnknown() {
-			return
-		}
-		resp.Diagnostics.Append(v.ElementsAs(ctx, target, false)...)
-	}
-	convertListHelper(data.PathLiterals, &builder.PathLiterals)
-	convertListHelper(data.PathPrefixes, &builder.PathPrefixes)
-	convertListHelper(data.ProcessBinaryPaths, &builder.ProcessBinaryPaths)
-	convertListHelper(data.ProcessCdHashes, &builder.ProcessCdHashes)
-	convertListHelper(data.ProcessSigningIds, &builder.ProcessSigningIds)
-	convertListHelper(data.ProcessCertificateSha256s, &builder.ProcessCertificateSha256S)
-	convertListHelper(data.ProcessTeamIds, &builder.ProcessTeamIds)
-
+	rule := buildFileAccessRule(ctx, data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	crResp, err := r.client.CreateFileAccessRule(ctx, apipb.CreateFileAccessRuleRequest_builder{
-		Rule: builder.Build(),
+		Rule: rule,
 	}.Build())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to create file access rule: %v", err))
@@ -417,9 +378,106 @@ func (r *FileAccessRuleResource) Read(ctx context.Context, req resource.ReadRequ
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// buildFileAccessRule builds the (upsert) FileAccessRule from the model.
+func buildFileAccessRule(ctx context.Context, data FileAccessRuleResourceModel, diags *diag.Diagnostics) *apipb.FileAccessRule {
+	ruleType := apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_UNSPECIFIED
+	switch data.RuleType.ValueString() {
+	case "PathsWithAllowedProcesses":
+		ruleType = apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_PATHS_WITH_ALLOWED_PROCESSES
+	case "PathsWithDeniedProcesses":
+		ruleType = apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_PATHS_WITH_DENIED_PROCESSES
+	case "ProcessesWithAllowedPaths":
+		ruleType = apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_PROCESSES_WITH_ALLOWED_PATHS
+	case "ProcessesWithDeniedPaths":
+		ruleType = apipb.FileAccessRuleType_FILE_ACCESS_RULE_TYPE_PROCESSES_WITH_DENIED_PATHS
+	}
+
+	builder := apipb.FileAccessRule_builder{
+		Tag:                 data.Tag.ValueString(),
+		Name:                data.Name.ValueString(),
+		AllowReadAccess:     data.AllowReadAccess.ValueBool(),
+		BlockViolations:     data.BlockViolations.ValueBool(),
+		RuleType:            ruleType,
+		EnableSilentMode:    data.EnableSilentMode.ValueBool(),
+		EnableSilentTtyMode: data.EnableSilentTtyMode.ValueBool(),
+		BlockMessage:        data.BlockMessage.ValueString(),
+		EventDetailUrl:      data.EventDetailUrl.ValueString(),
+		EventDetailText:     data.EventDetailText.ValueString(),
+	}
+
+	convertListHelper := func(v types.List, target *[]string) {
+		if v.IsNull() || v.IsUnknown() {
+			return
+		}
+		diags.Append(v.ElementsAs(ctx, target, false)...)
+	}
+	convertListHelper(data.PathLiterals, &builder.PathLiterals)
+	convertListHelper(data.PathPrefixes, &builder.PathPrefixes)
+	convertListHelper(data.ProcessBinaryPaths, &builder.ProcessBinaryPaths)
+	convertListHelper(data.ProcessCdHashes, &builder.ProcessCdHashes)
+	convertListHelper(data.ProcessSigningIds, &builder.ProcessSigningIds)
+	convertListHelper(data.ProcessCertificateSha256s, &builder.ProcessCertificateSha256S)
+	convertListHelper(data.ProcessTeamIds, &builder.ProcessTeamIds)
+
+	return builder.Build()
+}
+
 func (r *FileAccessRuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// File access rules don't support in-place updates. Users need to delete and recreate.
-	resp.Diagnostics.AddError("Client Error", "nps_workshop_file_access_rule does not support in-place updates")
+	var plan, state FileAccessRuleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newID, diags := r.upsertFileAccessRule(ctx, plan, state)
+	resp.Diagnostics.Append(diags...)
+	if newID.IsNull() {
+		return
+	}
+	plan.Id = newID
+	tflog.Info(ctx, fmt.Sprintf("Updated file access rule: %d", plan.Id.ValueInt64()))
+
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, FileAccessRuleIdentityModel{Id: plan.Id})...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// upsertFileAccessRule performs an atomic update via the CreateFileAccessRule
+// upsert RPC (keyed on (tag, name)) and returns the new rule ID. A matching
+// rule is atomically superseded, so a failed update leaves the old rule in
+// place. When the key changed, the upsert created a distinct new rule and left
+// the old one active, so we delete the old rule afterwards (a failed cleanup is
+// a warning, not an error). Returns a null ID (with diagnostics) on failure.
+func (r *FileAccessRuleResource) upsertFileAccessRule(ctx context.Context, plan, state FileAccessRuleResourceModel) (types.Int64, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	rule := buildFileAccessRule(ctx, plan, &diags)
+	if diags.HasError() {
+		return types.Int64Null(), diags
+	}
+
+	crResp, err := r.client.CreateFileAccessRule(ctx, apipb.CreateFileAccessRuleRequest_builder{
+		Rule: rule,
+	}.Build())
+	if err != nil {
+		diags.AddError("Client Error", fmt.Sprintf("Failed to update file access rule: %v", err))
+		return types.Int64Null(), diags
+	}
+	newID := types.Int64Value(crResp.GetRuleId())
+
+	keyChanged := !plan.Tag.Equal(state.Tag) || !plan.Name.Equal(state.Name)
+	if keyChanged && !state.Id.IsNull() {
+		if _, err := r.client.DeleteFileAccessRule(ctx, apipb.DeleteFileAccessRuleRequest_builder{
+			RuleId: proto.Int64(state.Id.ValueInt64()),
+		}.Build()); err != nil {
+			diags.AddWarning(
+				"Failed to delete superseded file access rule",
+				fmt.Sprintf("The updated rule was created (ID %d), but deleting the old rule (ID %d) failed: %v. You may need to delete it manually.",
+					newID.ValueInt64(), state.Id.ValueInt64(), err),
+			)
+		}
+	}
+	return newID, diags
 }
 
 func (r *FileAccessRuleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_package_rule.go
+++ b/internal/provider/resource_package_rule.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -71,14 +73,20 @@ func (r *PackageRuleResource) Metadata(ctx context.Context, req resource.Metadat
 
 func (r *PackageRuleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "The nps_workshop_package_rule resource manages Package Rules. Package rules sync identifiers from GAL for a package. Management of package rules requires the read:rules and write:rules permissions.",
-		MarkdownDescription: "The `nps_workshop_package_rule` resource manages Package Rules.\n\nPackage rules sync identifiers from GAL for a package.\n\nManagement of package rules requires the `read:rules` and `write:rules` permissions.",
+		Description:         "The nps_workshop_package_rule resource manages Package Rules. Package rules sync identifiers from GAL for a package. Management of package rules requires the read:rules and write:rules permissions. Changing tag, name, or source forces replacement; add a create_before_destroy lifecycle block to avoid a window where the rule does not exist.",
+		MarkdownDescription: "The `nps_workshop_package_rule` resource manages Package Rules.\n\nPackage rules sync identifiers from GAL for a package.\n\nManagement of package rules requires the `read:rules` and `write:rules` permissions.\n\nUpdates to non-key fields (such as `policy`) are applied atomically in place. Changing the rule's natural key (`tag`, `name`, or `source`) forces the rule to be replaced: by default Terraform destroys the old rule before creating the new one, leaving a brief window with no rule in place. To avoid that window, add a `create_before_destroy` lifecycle block:\n\n```hcl\nresource \"nps_workshop_package_rule\" \"example\" {\n  # ...\n  lifecycle {\n    create_before_destroy = true\n  }\n}\n```",
 
 		Attributes: map[string]schema.Attribute{
 			"tag": schema.StringAttribute{
 				Description:         "The tag for this package rule. The tag determines which hosts this rule will apply to. The tag must already exist in Workshop.",
 				MarkdownDescription: "The tag for this package rule. The tag determines which hosts this rule will apply to. The tag must already exist in Workshop.",
 				Required:            true,
+				// Part of the natural key (tag, name, source). The upsert only
+				// supersedes the old rule when the key matches, so changing the key
+				// must replace rather than update in place.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"source": schema.StringAttribute{
 				Description:         "The package source (e.g., PACKAGE_SOURCE_HOMEBREW, PACKAGE_SOURCE_NPM).",
@@ -87,11 +95,19 @@ func (r *PackageRuleResource) Schema(ctx context.Context, req resource.SchemaReq
 				Validators: []validator.String{
 					stringvalidator.OneOf(utils.ProtoEnumToList(apipb.PackageSource(0).Descriptor())...),
 				},
+				// Part of the natural key; see tag.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Description:         "The package name (e.g., \"wget\", \"express\").",
 				MarkdownDescription: "The package name (e.g., `wget`, `express`).",
 				Required:            true,
+				// Part of the natural key; see tag.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"policy": schema.StringAttribute{
 				Description:         "The policy for execution rules created from this package rule.",
@@ -286,14 +302,13 @@ func buildPackageRule(data PackageRuleResourceModel, diags *diag.Diagnostics) *a
 }
 
 func (r *PackageRuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state PackageRuleResourceModel
+	var plan PackageRuleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	newID, diags := r.upsertPackageRule(ctx, plan, state)
+	newID, diags := r.upsertPackageRule(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if newID.IsNull() {
 		return
@@ -306,12 +321,13 @@ func (r *PackageRuleResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 // upsertPackageRule performs an atomic update via the CreatePackageRule upsert
-// RPC (keyed on (tag, name, source)) and returns the new rule ID. A matching
-// rule is atomically superseded, so a failed update leaves the old rule in
-// place. When the key changed, the upsert created a distinct new rule and left
-// the old one active, so we delete the old rule afterwards (a failed cleanup is
-// a warning, not an error). Returns a null ID (with diagnostics) on failure.
-func (r *PackageRuleResource) upsertPackageRule(ctx context.Context, plan, state PackageRuleResourceModel) (types.Int64, diag.Diagnostics) {
+// RPC (keyed on (tag, name, source)) and returns the new rule ID. The server
+// supersedes the existing rule sharing this key and returns a new ID, so the
+// update is atomic and a failure leaves the old rule in place. The key
+// attributes are RequiresReplace, so Update only ever changes non-key fields
+// where the server is guaranteed to supersede; we never delete the old rule
+// ourselves. Returns a null ID (with diagnostics) on failure.
+func (r *PackageRuleResource) upsertPackageRule(ctx context.Context, plan PackageRuleResourceModel) (types.Int64, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	rule := buildPackageRule(plan, &diags)
@@ -326,23 +342,7 @@ func (r *PackageRuleResource) upsertPackageRule(ctx context.Context, plan, state
 		diags.AddError("Client Error", fmt.Sprintf("Failed to update package rule: %v", err))
 		return types.Int64Null(), diags
 	}
-	newID := types.Int64Value(crResp.GetRuleId())
-
-	keyChanged := !plan.Tag.Equal(state.Tag) ||
-		!plan.Name.Equal(state.Name) ||
-		!plan.Source.Equal(state.Source)
-	if keyChanged && !state.Id.IsNull() {
-		if _, err := r.client.DeletePackageRule(ctx, apipb.DeletePackageRuleRequest_builder{
-			RuleId: proto.Int64(state.Id.ValueInt64()),
-		}.Build()); err != nil {
-			diags.AddWarning(
-				"Failed to delete superseded package rule",
-				fmt.Sprintf("The updated rule was created (ID %d), but deleting the old rule (ID %d) failed: %v. You may need to delete it manually.",
-					newID.ValueInt64(), state.Id.ValueInt64(), err),
-			)
-		}
-	}
-	return newID, diags
+	return types.Int64Value(crResp.GetRuleId()), diags
 }
 
 func (r *PackageRuleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_package_rule.go
+++ b/internal/provider/resource_package_rule.go
@@ -147,7 +147,7 @@ func (r *PackageRuleResource) Schema(ctx context.Context, req resource.SchemaReq
 			// whenever the rule changes.
 			"id": schema.Int64Attribute{
 				Computed:            true,
-				MarkdownDescription: "The automatically generated ID of this package rule",
+				MarkdownDescription: "The server-generated ID of this package rule. This ID is reassigned on every upsert, including in-place updates, so it must not be relied on as a stable identifier across applies.",
 			},
 		},
 	}

--- a/internal/provider/resource_package_rule.go
+++ b/internal/provider/resource_package_rule.go
@@ -8,14 +8,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -65,6 +64,9 @@ type PackageRuleResourceModel struct {
 
 func (r *PackageRuleResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_workshop_package_rule"
+	// The rule ID (used as the identity) changes on every upsert, including
+	// in-place updates, so the identity is mutable across the resource's life.
+	resp.ResourceBehavior.MutableIdentity = true
 }
 
 func (r *PackageRuleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -123,13 +125,13 @@ func (r *PackageRuleResource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional:            true,
 			},
 
-			// Computed value, returned from Create
+			// Computed value, returned from Create. The ID changes on every
+			// upsert (including in-place updates), so it is intentionally left
+			// without UseStateForUnknown: it plans as "known after apply"
+			// whenever the rule changes.
 			"id": schema.Int64Attribute{
 				Computed:            true,
 				MarkdownDescription: "The automatically generated ID of this package rule",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 		},
 	}
@@ -162,42 +164,13 @@ func (r *PackageRuleResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	// Convert enum strings to enum values
-	source := apipb.PackageSource_value[data.Source.ValueString()]
-	policy := apipb.Policy_value[data.Policy.ValueString()]
-	ruleType := apipb.RuleType_value[data.RuleType.ValueString()]
-
-	// Build the package rule
-	builder := apipb.PackageRule_builder{
-		Tag:           data.Tag.ValueString(),
-		Source:        apipb.PackageSource(source),
-		Name:          data.Name.ValueString(),
-		Policy:        apipb.Policy(policy),
-		RuleType:      apipb.RuleType(ruleType),
-		VersionRegexp: data.VersionRegexp.ValueString(),
-	}
-
-	// Parse and set optional timestamp fields
-	if !data.MinDate.IsNull() && !data.MinDate.IsUnknown() {
-		t, err := time.Parse(time.RFC3339, data.MinDate.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("Invalid min_date", fmt.Sprintf("Failed to parse min_date: %v", err))
-			return
-		}
-		builder.MinDate = timestamppb.New(t)
-	}
-
-	if !data.MaxDate.IsNull() && !data.MaxDate.IsUnknown() {
-		t, err := time.Parse(time.RFC3339, data.MaxDate.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("Invalid max_date", fmt.Sprintf("Failed to parse max_date: %v", err))
-			return
-		}
-		builder.MaxDate = timestamppb.New(t)
+	rule := buildPackageRule(data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	crResp, err := r.client.CreatePackageRule(ctx, apipb.CreatePackageRuleRequest_builder{
-		Rule: builder.Build(),
+		Rule: rule,
 	}.Build())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to create package rule: %v", err))
@@ -276,9 +249,100 @@ func (r *PackageRuleResource) Read(ctx context.Context, req resource.ReadRequest
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// buildPackageRule builds the (upsert) PackageRule from the model.
+func buildPackageRule(data PackageRuleResourceModel, diags *diag.Diagnostics) *apipb.PackageRule {
+	source := apipb.PackageSource_value[data.Source.ValueString()]
+	policy := apipb.Policy_value[data.Policy.ValueString()]
+	ruleType := apipb.RuleType_value[data.RuleType.ValueString()]
+
+	builder := apipb.PackageRule_builder{
+		Tag:           data.Tag.ValueString(),
+		Source:        apipb.PackageSource(source),
+		Name:          data.Name.ValueString(),
+		Policy:        apipb.Policy(policy),
+		RuleType:      apipb.RuleType(ruleType),
+		VersionRegexp: data.VersionRegexp.ValueString(),
+	}
+
+	if !data.MinDate.IsNull() && !data.MinDate.IsUnknown() {
+		t, err := time.Parse(time.RFC3339, data.MinDate.ValueString())
+		if err != nil {
+			diags.AddError("Invalid min_date", fmt.Sprintf("Failed to parse min_date: %v", err))
+		} else {
+			builder.MinDate = timestamppb.New(t)
+		}
+	}
+
+	if !data.MaxDate.IsNull() && !data.MaxDate.IsUnknown() {
+		t, err := time.Parse(time.RFC3339, data.MaxDate.ValueString())
+		if err != nil {
+			diags.AddError("Invalid max_date", fmt.Sprintf("Failed to parse max_date: %v", err))
+		} else {
+			builder.MaxDate = timestamppb.New(t)
+		}
+	}
+
+	return builder.Build()
+}
+
 func (r *PackageRuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// Package rules don't support in-place updates. Users need to delete and recreate.
-	resp.Diagnostics.AddError("Client Error", "nps_workshop_package_rule does not support in-place updates")
+	var plan, state PackageRuleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newID, diags := r.upsertPackageRule(ctx, plan, state)
+	resp.Diagnostics.Append(diags...)
+	if newID.IsNull() {
+		return
+	}
+	plan.Id = newID
+	tflog.Info(ctx, fmt.Sprintf("Updated package rule: %d", plan.Id.ValueInt64()))
+
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, PackageRuleIdentityModel{Id: plan.Id})...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// upsertPackageRule performs an atomic update via the CreatePackageRule upsert
+// RPC (keyed on (tag, name, source)) and returns the new rule ID. A matching
+// rule is atomically superseded, so a failed update leaves the old rule in
+// place. When the key changed, the upsert created a distinct new rule and left
+// the old one active, so we delete the old rule afterwards (a failed cleanup is
+// a warning, not an error). Returns a null ID (with diagnostics) on failure.
+func (r *PackageRuleResource) upsertPackageRule(ctx context.Context, plan, state PackageRuleResourceModel) (types.Int64, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	rule := buildPackageRule(plan, &diags)
+	if diags.HasError() {
+		return types.Int64Null(), diags
+	}
+
+	crResp, err := r.client.CreatePackageRule(ctx, apipb.CreatePackageRuleRequest_builder{
+		Rule: rule,
+	}.Build())
+	if err != nil {
+		diags.AddError("Client Error", fmt.Sprintf("Failed to update package rule: %v", err))
+		return types.Int64Null(), diags
+	}
+	newID := types.Int64Value(crResp.GetRuleId())
+
+	keyChanged := !plan.Tag.Equal(state.Tag) ||
+		!plan.Name.Equal(state.Name) ||
+		!plan.Source.Equal(state.Source)
+	if keyChanged && !state.Id.IsNull() {
+		if _, err := r.client.DeletePackageRule(ctx, apipb.DeletePackageRuleRequest_builder{
+			RuleId: proto.Int64(state.Id.ValueInt64()),
+		}.Build()); err != nil {
+			diags.AddWarning(
+				"Failed to delete superseded package rule",
+				fmt.Sprintf("The updated rule was created (ID %d), but deleting the old rule (ID %d) failed: %v. You may need to delete it manually.",
+					newID.ValueInt64(), state.Id.ValueInt64(), err),
+			)
+		}
+	}
+	return newID, diags
 }
 
 func (r *PackageRuleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_rule_update_unit_test.go
+++ b/internal/provider/resource_rule_update_unit_test.go
@@ -25,8 +25,9 @@ type fakeWorkshopClient struct {
 	createErr error
 	newID     int64 // returned ruleId on create (int64-keyed resources)
 
-	created     bool
-	deleteCalls int
+	created       bool
+	deleteCalls   int
+	lastCreateReq *apipb.CreateRuleRequest // captured for payload assertions
 }
 
 func (f *fakeWorkshopClient) CreateRule(ctx context.Context, in *apipb.CreateRuleRequest, _ ...grpc.CallOption) (*apipb.CreateRuleResponse, error) {
@@ -34,6 +35,7 @@ func (f *fakeWorkshopClient) CreateRule(ctx context.Context, in *apipb.CreateRul
 		return nil, f.createErr
 	}
 	f.created = true
+	f.lastCreateReq = in
 	return apipb.CreateRuleResponse_builder{RuleId: proto.String("rule-new")}.Build(), nil
 }
 
@@ -124,6 +126,44 @@ func TestUpsertRuleUpsertsAndNeverDeletes(t *testing.T) {
 	// during an update (key changes are RequiresReplace, handled by Delete).
 	if fake.deleteCalls != 0 {
 		t.Errorf("Update must not delete; got %d delete calls", fake.deleteCalls)
+	}
+}
+
+// TestUpsertRulePropagatesBlockReason verifies the block_reason on the plan
+// (already resolved by blockReasonDefault) is sent on the upsert request. It
+// covers both the defaulted POLICY value and an explicit MALICIOUS value, and
+// confirms an unset reason is not sent.
+func TestUpsertRulePropagatesBlockReason(t *testing.T) {
+	cases := []struct {
+		name        string
+		blockReason types.String
+		want        apipb.Rule_BlockReason
+	}{
+		{"defaulted policy", types.StringValue("BLOCK_REASON_POLICY"), apipb.Rule_BLOCK_REASON_POLICY},
+		{"explicit malicious", types.StringValue("BLOCK_REASON_MALICIOUS"), apipb.Rule_BLOCK_REASON_MALICIOUS},
+		{"unset", types.StringNull(), apipb.Rule_BLOCK_REASON_UNSPECIFIED},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fake := &fakeWorkshopClient{}
+			r := &RuleResource{client: fake}
+
+			plan := RuleResourceModel{
+				Identifier:  types.StringValue("abc"),
+				RuleType:    types.StringValue("BINARY"),
+				Tag:         types.StringValue("global"),
+				Policy:      types.StringValue("BLOCKLIST"),
+				BlockReason: c.blockReason,
+			}
+
+			if _, diags := r.upsertRule(context.Background(), plan); diags.HasError() {
+				t.Fatalf("unexpected error diags: %v", diags)
+			}
+			got := fake.lastCreateReq.GetRule().GetBlockReason()
+			if got != c.want {
+				t.Errorf("block_reason: got %v, want %v", got, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/provider/resource_rule_update_unit_test.go
+++ b/internal/provider/resource_rule_update_unit_test.go
@@ -1,0 +1,315 @@
+// Copyright 2026 North Pole Security, Inc.
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	svcpb "buf.build/gen/go/northpolesec/workshop-api/grpc/go/workshop/v1/workshopv1grpc"
+	apipb "buf.build/gen/go/northpolesec/workshop-api/protocolbuffers/go/workshop/v1"
+)
+
+// fakeWorkshopClient embeds the full client interface (so it satisfies it) and
+// only overrides the rule create/delete RPCs the update path uses. Any other
+// call panics, which is what we want for a focused unit test.
+type fakeWorkshopClient struct {
+	svcpb.WorkshopServiceClient
+
+	createErr error
+	deleteErr error
+	newID     int64 // returned ruleId on create
+
+	created   bool
+	deletedID int64 // 0 means no delete happened (rule IDs are non-zero)
+}
+
+func (f *fakeWorkshopClient) CreateRule(ctx context.Context, in *apipb.CreateRuleRequest, _ ...grpc.CallOption) (*apipb.CreateRuleResponse, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	f.created = true
+	return apipb.CreateRuleResponse_builder{RuleId: proto.String("rule-new")}.Build(), nil
+}
+
+func (f *fakeWorkshopClient) DeleteRule(ctx context.Context, in *apipb.DeleteRuleRequest, _ ...grpc.CallOption) (*apipb.DeleteRuleResponse, error) {
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+	// rule IDs are strings here; record that delete happened.
+	f.deletedID = 1
+	return apipb.DeleteRuleResponse_builder{}.Build(), nil
+}
+
+func (f *fakeWorkshopClient) CreateFileAccessRule(ctx context.Context, in *apipb.CreateFileAccessRuleRequest, _ ...grpc.CallOption) (*apipb.CreateFileAccessRuleResponse, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	f.created = true
+	return apipb.CreateFileAccessRuleResponse_builder{RuleId: &f.newID}.Build(), nil
+}
+
+func (f *fakeWorkshopClient) DeleteFileAccessRule(ctx context.Context, in *apipb.DeleteFileAccessRuleRequest, _ ...grpc.CallOption) (*apipb.DeleteFileAccessRuleResponse, error) {
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+	f.deletedID = in.GetRuleId()
+	return apipb.DeleteFileAccessRuleResponse_builder{}.Build(), nil
+}
+
+func (f *fakeWorkshopClient) CreatePackageRule(ctx context.Context, in *apipb.CreatePackageRuleRequest, _ ...grpc.CallOption) (*apipb.CreatePackageRuleResponse, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	f.created = true
+	return apipb.CreatePackageRuleResponse_builder{RuleId: &f.newID}.Build(), nil
+}
+
+func (f *fakeWorkshopClient) DeletePackageRule(ctx context.Context, in *apipb.DeletePackageRuleRequest, _ ...grpc.CallOption) (*apipb.DeletePackageRuleResponse, error) {
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+	f.deletedID = in.GetRuleId()
+	return apipb.DeletePackageRuleResponse_builder{}.Build(), nil
+}
+
+func TestResolveBlockReason(t *testing.T) {
+	cases := []struct {
+		policy string
+		want   string // "" means null
+	}{
+		{"BLOCKLIST", "BLOCK_REASON_POLICY"},
+		{"SILENT_BLOCKLIST", "BLOCK_REASON_POLICY"},
+		{"SILENT_GUI_BLOCKLIST", "BLOCK_REASON_POLICY"},
+		{"SILENT_TTY_BLOCKLIST", "BLOCK_REASON_POLICY"},
+		{"ALLOWLIST", ""},
+		{"ALLOWLIST_COMPILER", ""},
+		{"SEATBELT", ""},
+		{"CEL", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := resolveBlockReason(c.policy)
+		if c.want == "" {
+			if !got.IsNull() {
+				t.Errorf("policy %q: expected null block_reason, got %q", c.policy, got.ValueString())
+			}
+			continue
+		}
+		if got.ValueString() != c.want {
+			t.Errorf("policy %q: expected %q, got %q", c.policy, c.want, got.ValueString())
+		}
+	}
+}
+
+// --- workshop_rule -------------------------------------------------------
+
+func TestUpsertRuleKeyUnchanged(t *testing.T) {
+	fake := &fakeWorkshopClient{}
+	r := &RuleResource{client: fake}
+
+	state := RuleResourceModel{
+		Identifier: types.StringValue("abc"),
+		RuleType:   types.StringValue("BINARY"),
+		Tag:        types.StringValue("global"),
+		Policy:     types.StringValue("ALLOWLIST"),
+		Id:         types.StringValue("rule-old"),
+	}
+	plan := state
+	plan.Policy = types.StringValue("BLOCKLIST") // content change, key identical
+
+	newID, diags := r.upsertRule(context.Background(), plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected error diags: %v", diags)
+	}
+	if newID.ValueString() != "rule-new" {
+		t.Errorf("expected new ID rule-new, got %q", newID.ValueString())
+	}
+	if !fake.created {
+		t.Error("expected CreateRule (upsert) to be called")
+	}
+	if fake.deletedID != 0 {
+		t.Error("key unchanged: old rule must NOT be deleted (server supersedes it)")
+	}
+}
+
+func TestUpsertRuleKeyChangedDeletesOld(t *testing.T) {
+	fake := &fakeWorkshopClient{}
+	r := &RuleResource{client: fake}
+
+	state := RuleResourceModel{
+		Identifier: types.StringValue("abc"),
+		RuleType:   types.StringValue("BINARY"),
+		Tag:        types.StringValue("global"),
+		Id:         types.StringValue("rule-old"),
+	}
+	plan := state
+	plan.Identifier = types.StringValue("def") // key change
+
+	newID, diags := r.upsertRule(context.Background(), plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected error diags: %v", diags)
+	}
+	if newID.ValueString() != "rule-new" {
+		t.Errorf("expected new ID rule-new, got %q", newID.ValueString())
+	}
+	if fake.deletedID == 0 {
+		t.Error("key changed: old rule must be deleted")
+	}
+}
+
+func TestUpsertRuleCreateErrorReturnsNullAndDoesNotDelete(t *testing.T) {
+	fake := &fakeWorkshopClient{createErr: errors.New("boom")}
+	r := &RuleResource{client: fake}
+
+	state := RuleResourceModel{
+		Identifier: types.StringValue("abc"),
+		RuleType:   types.StringValue("BINARY"),
+		Tag:        types.StringValue("global"),
+		Id:         types.StringValue("rule-old"),
+	}
+	plan := state
+	plan.Identifier = types.StringValue("def")
+
+	newID, diags := r.upsertRule(context.Background(), plan, state)
+	if !diags.HasError() {
+		t.Error("expected an error diagnostic when the upsert fails")
+	}
+	if !newID.IsNull() {
+		t.Errorf("expected null ID on failure, got %q", newID.ValueString())
+	}
+	if fake.deletedID != 0 {
+		t.Error("upsert failed: the old rule must be left untouched")
+	}
+}
+
+func TestUpsertRuleDeleteFailureIsWarningNotError(t *testing.T) {
+	fake := &fakeWorkshopClient{deleteErr: errors.New("nope")}
+	r := &RuleResource{client: fake}
+
+	state := RuleResourceModel{
+		Identifier: types.StringValue("abc"),
+		RuleType:   types.StringValue("BINARY"),
+		Tag:        types.StringValue("global"),
+		Id:         types.StringValue("rule-old"),
+	}
+	plan := state
+	plan.Identifier = types.StringValue("def") // key change triggers delete
+
+	newID, diags := r.upsertRule(context.Background(), plan, state)
+	if diags.HasError() {
+		t.Errorf("a failed cleanup should be a warning, not an error: %v", diags)
+	}
+	if diags.WarningsCount() != 1 {
+		t.Errorf("expected 1 warning, got %d", diags.WarningsCount())
+	}
+	if newID.ValueString() != "rule-new" {
+		t.Errorf("new rule should still be tracked, got %q", newID.ValueString())
+	}
+}
+
+// --- file_access_rule ----------------------------------------------------
+
+func TestUpsertFileAccessRuleKeyChangeDeletesOld(t *testing.T) {
+	fake := &fakeWorkshopClient{newID: 99}
+	r := &FileAccessRuleResource{client: fake}
+
+	state := FileAccessRuleResourceModel{
+		Tag:      types.StringValue("global"),
+		Name:     types.StringValue("old-name"),
+		RuleType: types.StringValue("PathsWithAllowedProcesses"),
+		Id:       types.Int64Value(42),
+	}
+	plan := state
+	plan.Name = types.StringValue("new-name") // key change
+
+	newID, diags := r.upsertFileAccessRule(context.Background(), plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected error diags: %v", diags)
+	}
+	if newID.ValueInt64() != 99 {
+		t.Errorf("expected new ID 99, got %d", newID.ValueInt64())
+	}
+	if fake.deletedID != 42 {
+		t.Errorf("key changed: expected delete of old ID 42, got %d", fake.deletedID)
+	}
+}
+
+func TestUpsertFileAccessRuleKeyUnchangedNoDelete(t *testing.T) {
+	fake := &fakeWorkshopClient{newID: 99}
+	r := &FileAccessRuleResource{client: fake}
+
+	state := FileAccessRuleResourceModel{
+		Tag:      types.StringValue("global"),
+		Name:     types.StringValue("name"),
+		RuleType: types.StringValue("PathsWithAllowedProcesses"),
+		Id:       types.Int64Value(42),
+	}
+	plan := state
+	plan.BlockViolations = types.BoolValue(true) // content-only change
+
+	_, diags := r.upsertFileAccessRule(context.Background(), plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected error diags: %v", diags)
+	}
+	if fake.deletedID != 0 {
+		t.Errorf("key unchanged: old rule must not be deleted, deleted %d", fake.deletedID)
+	}
+}
+
+// --- package_rule --------------------------------------------------------
+
+func TestUpsertPackageRuleKeyChangeDeletesOld(t *testing.T) {
+	fake := &fakeWorkshopClient{newID: 7}
+	r := &PackageRuleResource{client: fake}
+
+	state := PackageRuleResourceModel{
+		Tag:      types.StringValue("global"),
+		Source:   types.StringValue("PACKAGE_SOURCE_HOMEBREW"),
+		Name:     types.StringValue("wget"),
+		Policy:   types.StringValue("ALLOWLIST"),
+		RuleType: types.StringValue("BINARY"),
+		Id:       types.Int64Value(5),
+	}
+	plan := state
+	plan.Source = types.StringValue("PACKAGE_SOURCE_NPM") // key change
+
+	newID, diags := r.upsertPackageRule(context.Background(), plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected error diags: %v", diags)
+	}
+	if newID.ValueInt64() != 7 {
+		t.Errorf("expected new ID 7, got %d", newID.ValueInt64())
+	}
+	if fake.deletedID != 5 {
+		t.Errorf("key changed: expected delete of old ID 5, got %d", fake.deletedID)
+	}
+}
+
+func TestUpsertPackageRuleKeyUnchangedNoDelete(t *testing.T) {
+	fake := &fakeWorkshopClient{newID: 7}
+	r := &PackageRuleResource{client: fake}
+
+	state := PackageRuleResourceModel{
+		Tag:      types.StringValue("global"),
+		Source:   types.StringValue("PACKAGE_SOURCE_HOMEBREW"),
+		Name:     types.StringValue("wget"),
+		Policy:   types.StringValue("ALLOWLIST"),
+		RuleType: types.StringValue("BINARY"),
+		Id:       types.Int64Value(5),
+	}
+	plan := state
+	plan.Policy = types.StringValue("BLOCKLIST") // content-only change
+
+	_, diags := r.upsertPackageRule(context.Background(), plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected error diags: %v", diags)
+	}
+	if fake.deletedID != 0 {
+		t.Errorf("key unchanged: old rule must not be deleted, deleted %d", fake.deletedID)
+	}
+}

--- a/internal/provider/resource_rule_update_unit_test.go
+++ b/internal/provider/resource_rule_update_unit_test.go
@@ -16,16 +16,17 @@ import (
 
 // fakeWorkshopClient embeds the full client interface (so it satisfies it) and
 // only overrides the rule create/delete RPCs the update path uses. Any other
-// call panics, which is what we want for a focused unit test.
+// call panics, which is what we want for a focused unit test. The Delete*
+// methods record a call so tests can assert Update never deletes (the server
+// supersedes the old rule; deletion only happens via the resource's Delete).
 type fakeWorkshopClient struct {
 	svcpb.WorkshopServiceClient
 
 	createErr error
-	deleteErr error
-	newID     int64 // returned ruleId on create
+	newID     int64 // returned ruleId on create (int64-keyed resources)
 
-	created   bool
-	deletedID int64 // 0 means no delete happened (rule IDs are non-zero)
+	created     bool
+	deleteCalls int
 }
 
 func (f *fakeWorkshopClient) CreateRule(ctx context.Context, in *apipb.CreateRuleRequest, _ ...grpc.CallOption) (*apipb.CreateRuleResponse, error) {
@@ -37,11 +38,7 @@ func (f *fakeWorkshopClient) CreateRule(ctx context.Context, in *apipb.CreateRul
 }
 
 func (f *fakeWorkshopClient) DeleteRule(ctx context.Context, in *apipb.DeleteRuleRequest, _ ...grpc.CallOption) (*apipb.DeleteRuleResponse, error) {
-	if f.deleteErr != nil {
-		return nil, f.deleteErr
-	}
-	// rule IDs are strings here; record that delete happened.
-	f.deletedID = 1
+	f.deleteCalls++
 	return apipb.DeleteRuleResponse_builder{}.Build(), nil
 }
 
@@ -54,10 +51,7 @@ func (f *fakeWorkshopClient) CreateFileAccessRule(ctx context.Context, in *apipb
 }
 
 func (f *fakeWorkshopClient) DeleteFileAccessRule(ctx context.Context, in *apipb.DeleteFileAccessRuleRequest, _ ...grpc.CallOption) (*apipb.DeleteFileAccessRuleResponse, error) {
-	if f.deleteErr != nil {
-		return nil, f.deleteErr
-	}
-	f.deletedID = in.GetRuleId()
+	f.deleteCalls++
 	return apipb.DeleteFileAccessRuleResponse_builder{}.Build(), nil
 }
 
@@ -70,10 +64,7 @@ func (f *fakeWorkshopClient) CreatePackageRule(ctx context.Context, in *apipb.Cr
 }
 
 func (f *fakeWorkshopClient) DeletePackageRule(ctx context.Context, in *apipb.DeletePackageRuleRequest, _ ...grpc.CallOption) (*apipb.DeletePackageRuleResponse, error) {
-	if f.deleteErr != nil {
-		return nil, f.deleteErr
-	}
-	f.deletedID = in.GetRuleId()
+	f.deleteCalls++
 	return apipb.DeletePackageRuleResponse_builder{}.Build(), nil
 }
 
@@ -108,21 +99,18 @@ func TestResolveBlockReason(t *testing.T) {
 
 // --- workshop_rule -------------------------------------------------------
 
-func TestUpsertRuleKeyUnchanged(t *testing.T) {
+func TestUpsertRuleUpsertsAndNeverDeletes(t *testing.T) {
 	fake := &fakeWorkshopClient{}
 	r := &RuleResource{client: fake}
 
-	state := RuleResourceModel{
+	plan := RuleResourceModel{
 		Identifier: types.StringValue("abc"),
 		RuleType:   types.StringValue("BINARY"),
 		Tag:        types.StringValue("global"),
-		Policy:     types.StringValue("ALLOWLIST"),
-		Id:         types.StringValue("rule-old"),
+		Policy:     types.StringValue("BLOCKLIST"),
 	}
-	plan := state
-	plan.Policy = types.StringValue("BLOCKLIST") // content change, key identical
 
-	newID, diags := r.upsertRule(context.Background(), plan, state)
+	newID, diags := r.upsertRule(context.Background(), plan)
 	if diags.HasError() {
 		t.Fatalf("unexpected error diags: %v", diags)
 	}
@@ -132,184 +120,82 @@ func TestUpsertRuleKeyUnchanged(t *testing.T) {
 	if !fake.created {
 		t.Error("expected CreateRule (upsert) to be called")
 	}
-	if fake.deletedID != 0 {
-		t.Error("key unchanged: old rule must NOT be deleted (server supersedes it)")
+	// The server supersedes the old rule; the provider must never delete it
+	// during an update (key changes are RequiresReplace, handled by Delete).
+	if fake.deleteCalls != 0 {
+		t.Errorf("Update must not delete; got %d delete calls", fake.deleteCalls)
 	}
 }
 
-func TestUpsertRuleKeyChangedDeletesOld(t *testing.T) {
-	fake := &fakeWorkshopClient{}
-	r := &RuleResource{client: fake}
-
-	state := RuleResourceModel{
-		Identifier: types.StringValue("abc"),
-		RuleType:   types.StringValue("BINARY"),
-		Tag:        types.StringValue("global"),
-		Id:         types.StringValue("rule-old"),
-	}
-	plan := state
-	plan.Identifier = types.StringValue("def") // key change
-
-	newID, diags := r.upsertRule(context.Background(), plan, state)
-	if diags.HasError() {
-		t.Fatalf("unexpected error diags: %v", diags)
-	}
-	if newID.ValueString() != "rule-new" {
-		t.Errorf("expected new ID rule-new, got %q", newID.ValueString())
-	}
-	if fake.deletedID == 0 {
-		t.Error("key changed: old rule must be deleted")
-	}
-}
-
-func TestUpsertRuleCreateErrorReturnsNullAndDoesNotDelete(t *testing.T) {
+func TestUpsertRuleCreateErrorReturnsNull(t *testing.T) {
 	fake := &fakeWorkshopClient{createErr: errors.New("boom")}
 	r := &RuleResource{client: fake}
 
-	state := RuleResourceModel{
+	plan := RuleResourceModel{
 		Identifier: types.StringValue("abc"),
 		RuleType:   types.StringValue("BINARY"),
 		Tag:        types.StringValue("global"),
-		Id:         types.StringValue("rule-old"),
+		Policy:     types.StringValue("BLOCKLIST"),
 	}
-	plan := state
-	plan.Identifier = types.StringValue("def")
 
-	newID, diags := r.upsertRule(context.Background(), plan, state)
+	newID, diags := r.upsertRule(context.Background(), plan)
 	if !diags.HasError() {
 		t.Error("expected an error diagnostic when the upsert fails")
 	}
 	if !newID.IsNull() {
 		t.Errorf("expected null ID on failure, got %q", newID.ValueString())
 	}
-	if fake.deletedID != 0 {
-		t.Error("upsert failed: the old rule must be left untouched")
-	}
-}
-
-func TestUpsertRuleDeleteFailureIsWarningNotError(t *testing.T) {
-	fake := &fakeWorkshopClient{deleteErr: errors.New("nope")}
-	r := &RuleResource{client: fake}
-
-	state := RuleResourceModel{
-		Identifier: types.StringValue("abc"),
-		RuleType:   types.StringValue("BINARY"),
-		Tag:        types.StringValue("global"),
-		Id:         types.StringValue("rule-old"),
-	}
-	plan := state
-	plan.Identifier = types.StringValue("def") // key change triggers delete
-
-	newID, diags := r.upsertRule(context.Background(), plan, state)
-	if diags.HasError() {
-		t.Errorf("a failed cleanup should be a warning, not an error: %v", diags)
-	}
-	if diags.WarningsCount() != 1 {
-		t.Errorf("expected 1 warning, got %d", diags.WarningsCount())
-	}
-	if newID.ValueString() != "rule-new" {
-		t.Errorf("new rule should still be tracked, got %q", newID.ValueString())
+	if fake.deleteCalls != 0 {
+		t.Errorf("upsert failed: nothing should be deleted; got %d delete calls", fake.deleteCalls)
 	}
 }
 
 // --- file_access_rule ----------------------------------------------------
 
-func TestUpsertFileAccessRuleKeyChangeDeletesOld(t *testing.T) {
+func TestUpsertFileAccessRuleUpsertsAndNeverDeletes(t *testing.T) {
 	fake := &fakeWorkshopClient{newID: 99}
 	r := &FileAccessRuleResource{client: fake}
 
-	state := FileAccessRuleResourceModel{
+	plan := FileAccessRuleResourceModel{
 		Tag:      types.StringValue("global"),
-		Name:     types.StringValue("old-name"),
+		Name:     types.StringValue("name"),
 		RuleType: types.StringValue("PathsWithAllowedProcesses"),
-		Id:       types.Int64Value(42),
 	}
-	plan := state
-	plan.Name = types.StringValue("new-name") // key change
 
-	newID, diags := r.upsertFileAccessRule(context.Background(), plan, state)
+	newID, diags := r.upsertFileAccessRule(context.Background(), plan)
 	if diags.HasError() {
 		t.Fatalf("unexpected error diags: %v", diags)
 	}
 	if newID.ValueInt64() != 99 {
 		t.Errorf("expected new ID 99, got %d", newID.ValueInt64())
 	}
-	if fake.deletedID != 42 {
-		t.Errorf("key changed: expected delete of old ID 42, got %d", fake.deletedID)
-	}
-}
-
-func TestUpsertFileAccessRuleKeyUnchangedNoDelete(t *testing.T) {
-	fake := &fakeWorkshopClient{newID: 99}
-	r := &FileAccessRuleResource{client: fake}
-
-	state := FileAccessRuleResourceModel{
-		Tag:      types.StringValue("global"),
-		Name:     types.StringValue("name"),
-		RuleType: types.StringValue("PathsWithAllowedProcesses"),
-		Id:       types.Int64Value(42),
-	}
-	plan := state
-	plan.BlockViolations = types.BoolValue(true) // content-only change
-
-	_, diags := r.upsertFileAccessRule(context.Background(), plan, state)
-	if diags.HasError() {
-		t.Fatalf("unexpected error diags: %v", diags)
-	}
-	if fake.deletedID != 0 {
-		t.Errorf("key unchanged: old rule must not be deleted, deleted %d", fake.deletedID)
+	if fake.deleteCalls != 0 {
+		t.Errorf("Update must not delete; got %d delete calls", fake.deleteCalls)
 	}
 }
 
 // --- package_rule --------------------------------------------------------
 
-func TestUpsertPackageRuleKeyChangeDeletesOld(t *testing.T) {
+func TestUpsertPackageRuleUpsertsAndNeverDeletes(t *testing.T) {
 	fake := &fakeWorkshopClient{newID: 7}
 	r := &PackageRuleResource{client: fake}
 
-	state := PackageRuleResourceModel{
+	plan := PackageRuleResourceModel{
 		Tag:      types.StringValue("global"),
 		Source:   types.StringValue("PACKAGE_SOURCE_HOMEBREW"),
 		Name:     types.StringValue("wget"),
 		Policy:   types.StringValue("ALLOWLIST"),
 		RuleType: types.StringValue("BINARY"),
-		Id:       types.Int64Value(5),
 	}
-	plan := state
-	plan.Source = types.StringValue("PACKAGE_SOURCE_NPM") // key change
 
-	newID, diags := r.upsertPackageRule(context.Background(), plan, state)
+	newID, diags := r.upsertPackageRule(context.Background(), plan)
 	if diags.HasError() {
 		t.Fatalf("unexpected error diags: %v", diags)
 	}
 	if newID.ValueInt64() != 7 {
 		t.Errorf("expected new ID 7, got %d", newID.ValueInt64())
 	}
-	if fake.deletedID != 5 {
-		t.Errorf("key changed: expected delete of old ID 5, got %d", fake.deletedID)
-	}
-}
-
-func TestUpsertPackageRuleKeyUnchangedNoDelete(t *testing.T) {
-	fake := &fakeWorkshopClient{newID: 7}
-	r := &PackageRuleResource{client: fake}
-
-	state := PackageRuleResourceModel{
-		Tag:      types.StringValue("global"),
-		Source:   types.StringValue("PACKAGE_SOURCE_HOMEBREW"),
-		Name:     types.StringValue("wget"),
-		Policy:   types.StringValue("ALLOWLIST"),
-		RuleType: types.StringValue("BINARY"),
-		Id:       types.Int64Value(5),
-	}
-	plan := state
-	plan.Policy = types.StringValue("BLOCKLIST") // content-only change
-
-	_, diags := r.upsertPackageRule(context.Background(), plan, state)
-	if diags.HasError() {
-		t.Fatalf("unexpected error diags: %v", diags)
-	}
-	if fake.deletedID != 0 {
-		t.Errorf("key unchanged: old rule must not be deleted, deleted %d", fake.deletedID)
+	if fake.deleteCalls != 0 {
+		t.Errorf("Update must not delete; got %d delete calls", fake.deleteCalls)
 	}
 }

--- a/internal/provider/resource_settings_unit_test.go
+++ b/internal/provider/resource_settings_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	apipb "buf.build/gen/go/northpolesec/workshop-api/protocolbuffers/go/workshop/v1"
@@ -129,8 +130,8 @@ func TestRiskEngineRoundtrip(t *testing.T) {
 		RemotePlugins: []*apipb.RemoteRiskEnginePluginSettings{
 			apipb.RemoteRiskEnginePluginSettings_builder{
 				Enabled: &en,
-				Name:    strPtr("plugin-a"),
-				Url:     strPtr("https://example.invalid/plugin"),
+				Name:    proto.String("plugin-a"),
+				Url:     proto.String("https://example.invalid/plugin"),
 				Ttl:     durationpb.New(2 * 1e9),
 				Headers: []*apipb.HTTPHeader{
 					apipb.HTTPHeader_builder{Key: "X-Tenant", Value: "north-pole"}.Build(),
@@ -180,5 +181,3 @@ func TestRiskEngineRoundtrip(t *testing.T) {
 		t.Errorf("unexpected headers after roundtrip: %v", rp[0].GetHeaders())
 	}
 }
-
-func strPtr(s string) *string { return &s }

--- a/internal/provider/resource_workshop_rule.go
+++ b/internal/provider/resource_workshop_rule.go
@@ -97,6 +97,14 @@ func (m blockReasonDefault) PlanModifyString(ctx context.Context, req planmodifi
 		return
 	}
 
+	// The policy may reference an unknown value (e.g. another resource's
+	// computed attribute). We can't resolve the default until it is known, so
+	// leave block_reason unknown to be resolved on a later plan.
+	if policy.IsUnknown() {
+		resp.PlanValue = types.StringUnknown()
+		return
+	}
+
 	resp.PlanValue = resolveBlockReason(policy.ValueString())
 }
 
@@ -155,8 +163,8 @@ func (r *RuleResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				},
 			},
 			"block_reason": schema.StringAttribute{
-				Description:         "The block reason for this rule. The possible values are: BLOCK_REASON_POLICY and BLOCK_REASON_MALICIOUS.",
-				MarkdownDescription: "The block reason for this rule. The possible values are: `BLOCK_REASON_POLICY`, and `BLOCK_REASON_MALICIOUS`.",
+				Description:         "The block reason for this rule. Valid values are BLOCK_REASON_POLICY and BLOCK_REASON_MALICIOUS. For blocklist-family policies an unset value defaults to BLOCK_REASON_POLICY; leave it unset for non-blocklist policies, which cannot have a block reason.",
+				MarkdownDescription: "The block reason for this rule. Valid values are `BLOCK_REASON_POLICY` and `BLOCK_REASON_MALICIOUS`. For blocklist-family policies an unset value defaults to `BLOCK_REASON_POLICY`; leave it unset for non-blocklist policies, which cannot have a block reason.",
 				Optional:            true,
 				// Computed + blockReasonDefault: for blocklist policies the server
 				// treats an unset block_reason as BLOCK_REASON_POLICY. We resolve
@@ -206,7 +214,7 @@ func (r *RuleResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			// whenever the rule changes.
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "The automatically generated ID of this rule",
+				MarkdownDescription: "The server-generated ID of this rule. This ID is reassigned on every upsert, including in-place updates, so it must not be relied on as a stable identifier across applies.",
 			},
 		},
 

--- a/internal/provider/resource_workshop_rule.go
+++ b/internal/provider/resource_workshop_rule.go
@@ -4,9 +4,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -14,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/northpolesec/terraform-provider-nps/internal/utils"
@@ -68,8 +69,51 @@ type RuleAffectedHostThresholdModel struct {
 	Days      types.Int32 `tfsdk:"days"`
 }
 
+// blockReasonDefault resolves an unset block_reason the same way the server
+// does: blocklist-family policies default to BLOCK_REASON_POLICY, while other
+// policies (which the server forbids a block reason on) resolve to null. This
+// keeps an unset block_reason from showing a perpetual diff without copying the
+// value back from server state.
+type blockReasonDefault struct{}
+
+func (m blockReasonDefault) Description(context.Context) string {
+	return "Defaults block_reason to BLOCK_REASON_POLICY for blocklist policies when unset."
+}
+
+func (m blockReasonDefault) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m blockReasonDefault) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Respect an explicitly configured value.
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	var policy types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("policy"), &policy)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.PlanValue = resolveBlockReason(policy.ValueString())
+}
+
+// resolveBlockReason returns the block_reason for an unset config value given
+// the rule's policy: blocklist-family policies default to BLOCK_REASON_POLICY
+// (matching the server), everything else resolves to null.
+func resolveBlockReason(policy string) types.String {
+	if strings.Contains(policy, "BLOCKLIST") {
+		return types.StringValue("BLOCK_REASON_POLICY")
+	}
+	return types.StringNull()
+}
+
 func (r *RuleResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_workshop_rule"
+	// The rule ID (used as the identity) changes on every upsert, including
+	// in-place updates, so the identity is mutable across the resource's life.
+	resp.ResourceBehavior.MutableIdentity = true
 }
 
 func (r *RuleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -100,11 +144,19 @@ func (r *RuleResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				},
 			},
 			"block_reason": schema.StringAttribute{
-				Description:         "The block reason for this rule. The possible values are: POLICY and MALICIOUS.",
-				MarkdownDescription: "The block reason for this rule. The possible values are: `POLICY`, and `MALICIOUS`.",
+				Description:         "The block reason for this rule. The possible values are: BLOCK_REASON_POLICY and BLOCK_REASON_MALICIOUS.",
+				MarkdownDescription: "The block reason for this rule. The possible values are: `BLOCK_REASON_POLICY`, and `BLOCK_REASON_MALICIOUS`.",
 				Optional:            true,
+				// Computed + blockReasonDefault: for blocklist policies the server
+				// treats an unset block_reason as BLOCK_REASON_POLICY. We resolve
+				// that default ourselves at plan time so an unset value does not
+				// produce a perpetual diff against the server-assigned POLICY.
+				Computed: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(utils.ProtoEnumToList(apipb.Rule_BlockReason(0).Descriptor())...),
+				},
+				PlanModifiers: []planmodifier.String{
+					blockReasonDefault{},
 				},
 			},
 			"tag": schema.StringAttribute{
@@ -131,13 +183,13 @@ func (r *RuleResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional:            true,
 			},
 
-			// Computed value, returned from Create
+			// Computed value, returned from Create. The ID changes on every
+			// upsert (including in-place updates), so it is intentionally left
+			// without UseStateForUnknown: it plans as "known after apply"
+			// whenever the rule changes.
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The automatically generated ID of this rule",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 		},
 
@@ -230,35 +282,7 @@ func (r *RuleResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	ruleType := apipb.RuleType_value[data.RuleType.ValueString()]
-	rulePolicy := apipb.Policy_value[data.Policy.ValueString()]
-
-	rule := apipb.Rule_builder{
-		Identifier: data.Identifier.ValueString(),
-		RuleType:   apipb.RuleType(ruleType),
-		Policy:     apipb.Policy(rulePolicy),
-		Tag:        data.Tag.ValueString(),
-		Comment:    data.Comment.ValueString(),
-		CustomMsg:  data.CustomMsg.ValueString(),
-		CustomUrl:  data.CustomURL.ValueString(),
-		CelExpr:    data.CELExpr.ValueString(),
-	}.Build()
-
-	createReq := apipb.CreateRuleRequest_builder{
-		Rule: rule,
-	}
-	if data.AffectedHostThreshold != nil {
-		threshold := apipb.CreateRuleRequest_AffectedHostThreshold_builder{}
-		if !data.AffectedHostThreshold.HostCount.IsNull() && !data.AffectedHostThreshold.HostCount.IsUnknown() {
-			threshold.HostCount = proto.Int32(data.AffectedHostThreshold.HostCount.ValueInt32())
-		}
-		if !data.AffectedHostThreshold.Days.IsNull() && !data.AffectedHostThreshold.Days.IsUnknown() {
-			threshold.Days = proto.Int32(data.AffectedHostThreshold.Days.ValueInt32())
-		}
-		createReq.AffectedHostThreshold = threshold.Build()
-	}
-
-	crResp, err := r.client.CreateRule(ctx, createReq.Build())
+	crResp, err := r.client.CreateRule(ctx, buildCreateRuleRequest(data))
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to create rule: %v", err))
 		return
@@ -271,6 +295,41 @@ func (r *RuleResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// buildCreateRuleRequest builds the (upsert) CreateRuleRequest from the model.
+func buildCreateRuleRequest(data RuleResourceModel) *apipb.CreateRuleRequest {
+	ruleType := apipb.RuleType_value[data.RuleType.ValueString()]
+	rulePolicy := apipb.Policy_value[data.Policy.ValueString()]
+
+	ruleBuilder := apipb.Rule_builder{
+		Identifier: data.Identifier.ValueString(),
+		RuleType:   apipb.RuleType(ruleType),
+		Policy:     apipb.Policy(rulePolicy),
+		Tag:        data.Tag.ValueString(),
+		Comment:    data.Comment.ValueString(),
+		CustomMsg:  data.CustomMsg.ValueString(),
+		CustomUrl:  data.CustomURL.ValueString(),
+		CelExpr:    data.CELExpr.ValueString(),
+	}
+	if br := data.BlockReason.ValueString(); br != "" {
+		ruleBuilder.BlockReason = apipb.Rule_BlockReason(apipb.Rule_BlockReason_value[br])
+	}
+
+	createReq := apipb.CreateRuleRequest_builder{
+		Rule: ruleBuilder.Build(),
+	}
+	if data.AffectedHostThreshold != nil {
+		threshold := apipb.CreateRuleRequest_AffectedHostThreshold_builder{}
+		if !data.AffectedHostThreshold.HostCount.IsNull() && !data.AffectedHostThreshold.HostCount.IsUnknown() {
+			threshold.HostCount = proto.Int32(data.AffectedHostThreshold.HostCount.ValueInt32())
+		}
+		if !data.AffectedHostThreshold.Days.IsNull() && !data.AffectedHostThreshold.Days.IsUnknown() {
+			threshold.Days = proto.Int32(data.AffectedHostThreshold.Days.ValueInt32())
+		}
+		createReq.AffectedHostThreshold = threshold.Build()
+	}
+	return createReq.Build()
 }
 
 func (r *RuleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -338,9 +397,57 @@ func (r *RuleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *RuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// Because an "upsert" of a rule results in a new rule ID, it's not possible
-	// for us to implement in-place updates.
-	resp.Diagnostics.AddError("Client Error", "nps_workshop_rule does not support in-place updates")
+	var plan, state RuleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newID, diags := r.upsertRule(ctx, plan, state)
+	resp.Diagnostics.Append(diags...)
+	if newID.IsNull() {
+		return
+	}
+	plan.Id = newID
+
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, RuleIdentityModel{Id: plan.Id})...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// upsertRule performs an atomic update via the CreateRule upsert RPC and
+// returns the new rule ID. CreateRule is an upsert: when the (tag, rule_type,
+// identifier) key matches an existing rule, the server atomically supersedes it
+// and returns a new ID, so a failed update leaves the old rule in place. When
+// the key changed, the upsert instead created a distinct new rule and left the
+// old one active, so we delete the old rule afterwards. A failed cleanup is a
+// warning, not an error: the new rule is already in place. Returns a null ID
+// (with an error diagnostic) if the upsert itself failed.
+func (r *RuleResource) upsertRule(ctx context.Context, plan, state RuleResourceModel) (types.String, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	crResp, err := r.client.CreateRule(ctx, buildCreateRuleRequest(plan))
+	if err != nil {
+		diags.AddError("Client Error", fmt.Sprintf("Failed to update rule: %v", err))
+		return types.StringNull(), diags
+	}
+	newID := types.StringValue(crResp.GetRuleId())
+
+	keyChanged := !plan.Identifier.Equal(state.Identifier) ||
+		!plan.RuleType.Equal(state.RuleType) ||
+		!plan.Tag.Equal(state.Tag)
+	if keyChanged && state.Id.ValueString() != "" {
+		if _, err := r.client.DeleteRule(ctx, apipb.DeleteRuleRequest_builder{
+			RuleId: proto.String(state.Id.ValueString()),
+		}.Build()); err != nil {
+			diags.AddWarning(
+				"Failed to delete superseded rule",
+				fmt.Sprintf("The updated rule was created (ID %s), but deleting the old rule (ID %s) failed: %v. You may need to delete it manually.",
+					newID.ValueString(), state.Id.ValueString(), err),
+			)
+		}
+	}
+	return newID, diags
 }
 
 func (r *RuleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_workshop_rule.go
+++ b/internal/provider/resource_workshop_rule.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/northpolesec/terraform-provider-nps/internal/utils"
@@ -118,14 +119,20 @@ func (r *RuleResource) Metadata(ctx context.Context, req resource.MetadataReques
 
 func (r *RuleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "The nps_workshop_rule resource manages Rules. Management of rules requires the read:rules and write:rules permissions.",
-		MarkdownDescription: "The `nps_workshop_rule` resource manages Rules.\n\nManagement of rules requires the `read:rules` and `write:rules` permissions.",
+		Description:         "The nps_workshop_rule resource manages Rules. Management of rules requires the read:rules and write:rules permissions. Changing identifier, rule_type, or tag forces replacement; add a create_before_destroy lifecycle block to avoid a window where the rule does not exist.",
+		MarkdownDescription: "The `nps_workshop_rule` resource manages Rules.\n\nManagement of rules requires the `read:rules` and `write:rules` permissions.\n\nUpdates to non-key fields (such as `policy` or `comment`) are applied atomically in place. Changing the rule's natural key (`identifier`, `rule_type`, or `tag`) forces the rule to be replaced: by default Terraform destroys the old rule before creating the new one, leaving a brief window with no rule in place. To avoid that window, add a `create_before_destroy` lifecycle block:\n\n```hcl\nresource \"nps_workshop_rule\" \"example\" {\n  # ...\n  lifecycle {\n    create_before_destroy = true\n  }\n}\n```",
 
 		Attributes: map[string]schema.Attribute{
 			"identifier": schema.StringAttribute{
 				Description:         "The identifier for this rule. The format of this identifier depends on the rule type.",
 				MarkdownDescription: "The identifier for this rule. The format of this identifier depends on the rule type.",
 				Required:            true,
+				// Part of the natural key (identifier, rule_type, tag). The upsert
+				// only supersedes the old rule when the key matches, so changing the
+				// key must replace rather than update in place.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"rule_type": schema.StringAttribute{
 				Description:         "The type of this rule. The possible values are: BINARY, CERTIFICATE, TEAMID, SIGNINGID, and CDHASH.",
@@ -133,6 +140,10 @@ func (r *RuleResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(utils.ProtoEnumToList(apipb.RuleType(0).Descriptor())...),
+				},
+				// Part of the natural key; see identifier.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"policy": schema.StringAttribute{
@@ -153,7 +164,9 @@ func (r *RuleResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				// produce a perpetual diff against the server-assigned POLICY.
 				Computed: true,
 				Validators: []validator.String{
-					stringvalidator.OneOf(utils.ProtoEnumToList(apipb.Rule_BlockReason(0).Descriptor())...),
+					// Only the meaningful block reasons; BLOCK_REASON_UNSPECIFIED is
+					// reserved for the unset/default case handled by blockReasonDefault.
+					stringvalidator.OneOf("BLOCK_REASON_POLICY", "BLOCK_REASON_MALICIOUS"),
 				},
 				PlanModifiers: []planmodifier.String{
 					blockReasonDefault{},
@@ -163,6 +176,10 @@ func (r *RuleResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Description:         "The tag for this rule. The tag determines which hosts this rule will apply to. The tag must already exist in Workshop.",
 				MarkdownDescription: "The tag for this rule. The tag determines which hosts this rule will apply to. The tag must already exist in Workshop.",
 				Required:            true,
+				// Part of the natural key; see identifier.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"cel_expr": schema.StringAttribute{
 				Description:         "A CEL expression to evaluate when this rule matches. Only valid when the policy is set to CEL.",
@@ -397,14 +414,13 @@ func (r *RuleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *RuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state RuleResourceModel
+	var plan RuleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	newID, diags := r.upsertRule(ctx, plan, state)
+	newID, diags := r.upsertRule(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if newID.IsNull() {
 		return
@@ -416,14 +432,13 @@ func (r *RuleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 // upsertRule performs an atomic update via the CreateRule upsert RPC and
-// returns the new rule ID. CreateRule is an upsert: when the (tag, rule_type,
-// identifier) key matches an existing rule, the server atomically supersedes it
-// and returns a new ID, so a failed update leaves the old rule in place. When
-// the key changed, the upsert instead created a distinct new rule and left the
-// old one active, so we delete the old rule afterwards. A failed cleanup is a
-// warning, not an error: the new rule is already in place. Returns a null ID
-// (with an error diagnostic) if the upsert itself failed.
-func (r *RuleResource) upsertRule(ctx context.Context, plan, state RuleResourceModel) (types.String, diag.Diagnostics) {
+// returns the new rule ID. CreateRule is an upsert: the server supersedes the
+// existing rule sharing this rule's (tag, rule_type, identifier) key and
+// returns a new ID, so the update is atomic and a failure leaves the old rule
+// in place. The key attributes are RequiresReplace, so Update only ever changes
+// non-key fields where the server is guaranteed to supersede; we never delete
+// the old rule ourselves. Returns a null ID (with diagnostics) on failure.
+func (r *RuleResource) upsertRule(ctx context.Context, plan RuleResourceModel) (types.String, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	crResp, err := r.client.CreateRule(ctx, buildCreateRuleRequest(plan))
@@ -431,23 +446,7 @@ func (r *RuleResource) upsertRule(ctx context.Context, plan, state RuleResourceM
 		diags.AddError("Client Error", fmt.Sprintf("Failed to update rule: %v", err))
 		return types.StringNull(), diags
 	}
-	newID := types.StringValue(crResp.GetRuleId())
-
-	keyChanged := !plan.Identifier.Equal(state.Identifier) ||
-		!plan.RuleType.Equal(state.RuleType) ||
-		!plan.Tag.Equal(state.Tag)
-	if keyChanged && state.Id.ValueString() != "" {
-		if _, err := r.client.DeleteRule(ctx, apipb.DeleteRuleRequest_builder{
-			RuleId: proto.String(state.Id.ValueString()),
-		}.Build()); err != nil {
-			diags.AddWarning(
-				"Failed to delete superseded rule",
-				fmt.Sprintf("The updated rule was created (ID %s), but deleting the old rule (ID %s) failed: %v. You may need to delete it manually.",
-					newID.ValueString(), state.Id.ValueString(), err),
-			)
-		}
-	}
-	return newID, diags
+	return types.StringValue(crResp.GetRuleId()), diags
 }
 
 func (r *RuleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
Also add more unit tests and better handle the `block_reason` field on execution events to match server-side handling