### PR TITLE
sync_settings: Validate CEL fallback rules before apply

### DIFF
--- a/internal/provider/resource_rule_update_unit_test.go
+++ b/internal/provider/resource_rule_update_unit_test.go
@@ -35,6 +35,19 @@ type fakeWorkshopClient struct {
 	validateCELErr  error  // returned by ValidateCELRule
 	validateCELExpr string // captured expression
 	validateCELCall int    // number of ValidateCELRule calls
+
+	syncDeleteCalls int // number of DeleteSyncSettings calls
+	syncUpdateCalls int // number of UpdateSyncSettings calls
+}
+
+func (f *fakeWorkshopClient) DeleteSyncSettings(ctx context.Context, in *apipb.DeleteSyncSettingsRequest, _ ...grpc.CallOption) (*apipb.DeleteSyncSettingsResponse, error) {
+	f.syncDeleteCalls++
+	return apipb.DeleteSyncSettingsResponse_builder{}.Build(), nil
+}
+
+func (f *fakeWorkshopClient) UpdateSyncSettings(ctx context.Context, in *apipb.UpdateSyncSettingsRequest, _ ...grpc.CallOption) (*apipb.UpdateSyncSettingsResponse, error) {
+	f.syncUpdateCalls++
+	return apipb.UpdateSyncSettingsResponse_builder{}.Build(), nil
 }
 
 func (f *fakeWorkshopClient) ValidateCELRule(ctx context.Context, in *apipb.ValidateCELRuleRequest, _ ...grpc.CallOption) (*apipb.ValidateCELRuleResponse, error) {

--- a/internal/provider/resource_settings_sync.go
+++ b/internal/provider/resource_settings_sync.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/northpolesec/terraform-provider-nps/internal/utils"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	svcpb "buf.build/gen/go/northpolesec/workshop-api/grpc/go/workshop/v1/workshopv1grpc"
@@ -31,6 +32,7 @@ var _ resource.ResourceWithConfigure = &SyncSettingsResource{}
 var _ resource.ResourceWithImportState = &SyncSettingsResource{}
 var _ resource.ResourceWithIdentity = &SyncSettingsResource{}
 var _ resource.ResourceWithConfigValidators = &SyncSettingsResource{}
+var _ resource.ResourceWithModifyPlan = &SyncSettingsResource{}
 
 func NewSyncSettingsResource() resource.Resource {
 	return &SyncSettingsResource{}
@@ -376,6 +378,22 @@ func validateRemovablePolicyBlock(p path.Path, m *SyncSettingsRemovableMediaPoli
 	}
 }
 
+func (r *SyncSettingsResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// No plan to validate on destroy, and the client may be unset if the
+	// provider isn't fully configured (e.g. during validate).
+	if req.Plan.Raw.IsNull() || r.client == nil {
+		return
+	}
+
+	var data SyncSettingsResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	r.validateCelFallbackRules(ctx, data.CelFallbackRule, &resp.Diagnostics)
+}
+
 func (r *SyncSettingsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
@@ -523,6 +541,14 @@ func (r *SyncSettingsResource) IdentitySchema(ctx context.Context, req resource.
 // be deleted, so that tenants not using telemetry are never forced to call the
 // (feature-gated) telemetry RPCs.
 func (r *SyncSettingsResource) replaceTagSettings(ctx context.Context, data *SyncSettingsResourceModel, priorTelemetryEnabled types.Bool, diags *diag.Diagnostics) bool {
+	// Validate CEL fallback expressions server-side before the destructive
+	// delete/update below, so an invalid expression fails without clearing the
+	// tag's existing settings.
+	r.validateCelFallbackRules(ctx, data.CelFallbackRule, diags)
+	if diags.HasError() {
+		return false
+	}
+
 	ss, d := syncSettingsModelToProto(ctx, data)
 	diags.Append(d...)
 	if diags.HasError() {
@@ -546,6 +572,31 @@ func (r *SyncSettingsResource) replaceTagSettings(ctx context.Context, data *Syn
 	}
 
 	return r.applyTelemetryConfig(ctx, data.Tag.ValueString(), data.TelemetryEnabled, priorTelemetryEnabled, diags)
+}
+
+// validateCelFallbackRules asks the server to validate each fallback rule's CEL
+// expression. Expressions that are unknown (interpolated from another resource
+// at plan time) or empty are skipped; the schema already requires a non-empty
+// expression, so an empty value here can only be an unresolved reference.
+func (r *SyncSettingsResource) validateCelFallbackRules(ctx context.Context, rules []SyncSettingsCelFallbackRuleModel, diags *diag.Diagnostics) {
+	for i, rule := range rules {
+		if rule.Expression.IsUnknown() || rule.Expression.ValueString() == "" {
+			continue
+		}
+		if _, err := r.client.ValidateCELRule(ctx, apipb.ValidateCELRuleRequest_builder{
+			Expression: proto.String(rule.Expression.ValueString()),
+		}.Build()); err != nil {
+			msg := err.Error()
+			if st, ok := status.FromError(err); ok {
+				msg = st.Message()
+			}
+			diags.AddAttributeError(
+				path.Root("cel_fallback_rule").AtListIndex(i).AtName("expression"),
+				"Invalid CEL expression",
+				fmt.Sprintf("The CEL fallback expression failed validation: %s", msg),
+			)
+		}
+	}
 }
 
 // applyTelemetryConfig reconciles the tag's TelemetryConfig with the plan.

--- a/internal/provider/resource_settings_sync_unit_test.go
+++ b/internal/provider/resource_settings_sync_unit_test.go
@@ -3,14 +3,64 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/protobuf/proto"
 
 	apipb "buf.build/gen/go/northpolesec/workshop-api/protocolbuffers/go/workshop/v1"
 )
+
+// TestSyncSettingsCelFallbackValidation verifies that CEL fallback expressions
+// are validated before the destructive delete/update, so an invalid expression
+// leaves the tag's existing settings untouched.
+func TestSyncSettingsCelFallbackValidation(t *testing.T) {
+	ctx := context.Background()
+
+	for _, c := range []struct {
+		name          string
+		expr          string
+		validateErr   error
+		wantErr       bool
+		wantValidated int
+		wantMutated   bool
+	}{
+		{name: "valid", expr: "true", wantValidated: 1, wantMutated: true},
+		{name: "invalid", expr: "bogus(", validateErr: errors.New("syntax error"), wantErr: true, wantValidated: 1, wantMutated: false},
+		{name: "empty expr skips validation", expr: "", wantValidated: 0, wantMutated: true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fake := &fakeWorkshopClient{validateCELErr: c.validateErr}
+			r := &SyncSettingsResource{client: fake}
+			data := &SyncSettingsResourceModel{
+				Tag:              types.StringValue("dev"),
+				TelemetryEnabled: types.BoolNull(),
+				CelFallbackRule: []SyncSettingsCelFallbackRuleModel{
+					{Expression: types.StringValue(c.expr)},
+				},
+			}
+
+			var diags diag.Diagnostics
+			ok := r.replaceTagSettings(ctx, data, types.BoolNull(), &diags)
+
+			if diags.HasError() != c.wantErr {
+				t.Errorf("HasError=%v, want %v (diags: %v)", diags.HasError(), c.wantErr, diags)
+			}
+			if ok == c.wantErr {
+				t.Errorf("replaceTagSettings returned %v, want %v", ok, !c.wantErr)
+			}
+			if fake.validateCELCall != c.wantValidated {
+				t.Errorf("ValidateCELRule called %d times, want %d", fake.validateCELCall, c.wantValidated)
+			}
+			if mutated := fake.syncDeleteCalls > 0 || fake.syncUpdateCalls > 0; mutated != c.wantMutated {
+				t.Errorf("mutated=%v (delete=%d update=%d), want %v", mutated, fake.syncDeleteCalls, fake.syncUpdateCalls, c.wantMutated)
+			}
+		})
+	}
+}
 
 // TestSyncSettingsUnsetVsEmpty verifies the central requirement: an unset
 // Terraform attribute produces an absent proto field, while an attribute set


### PR DESCRIPTION
Due to the way sync settings are handled in the API it is not possible to atomically update sync settings in every instance, so we do a Delete followed by a Create. This leaves the possibility of a bad update deleting sync settings and leaving them unset. One of the biggest possible contributors to this is bad CEL expressions in fallback rules, so this PR adds validation of them, both at plan time, and as a backstop at apply time before the delete occurs.

A future release of the provider will attempt to make sync settings updates fully atomic but this is a good stop-gap measure.