### PR TITLE
Honor the documented endpoint environment variable

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,5 +52,4 @@ provider "nps" {
 ### Optional
 
 - `api_key` (String, Sensitive) The API key to use. Can also be supplied using the `WORKSHOP_API_KEY` environment variable. If no API key is provided, the provider will attempt to use a stored short-lived user token.
-- `endpoint` (String) The base URL for the Workshop instance. Can also be supplied using the `WORKSHOP_ENDPOINT` envrionment variable.
-
+- `endpoint` (String) The base URL for the Workshop instance. Can also be supplied using the `WORKSHOP_ENDPOINT` environment variable. `NPS_ENDPOINT` remains available as a deprecated fallback.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,7 +54,7 @@ func (p *NPSProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"endpoint": schema.StringAttribute{
-				MarkdownDescription: "The base URL for the Workshop instance. Can also be supplied using the `WORKSHOP_ENDPOINT` envrionment variable.",
+				MarkdownDescription: "The base URL for the Workshop instance. Can also be supplied using the `WORKSHOP_ENDPOINT` environment variable. `NPS_ENDPOINT` remains available as a deprecated fallback.",
 				Optional:            true,
 			},
 			"api_key": schema.StringAttribute{
@@ -66,6 +66,22 @@ func (p *NPSProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 	}
 }
 
+// resolveEndpoint applies the provider's endpoint precedence. Explicit
+// configuration wins over environment variables, and WORKSHOP_ENDPOINT wins
+// over the deprecated NPS_ENDPOINT alias.
+func resolveEndpoint(configured string) (endpoint string, usedDeprecatedEnv bool) {
+	if configured != "" {
+		return configured, false
+	}
+	if endpoint := os.Getenv("WORKSHOP_ENDPOINT"); endpoint != "" {
+		return endpoint, false
+	}
+	if endpoint := os.Getenv("NPS_ENDPOINT"); endpoint != "" {
+		return endpoint, true
+	}
+	return "", false
+}
+
 func (p *NPSProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	var data NPSProviderModel
 
@@ -74,14 +90,17 @@ func (p *NPSProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		return
 	}
 
-	// Validate endpoint
-	endpoint := data.Endpoint.ValueString()
-	if e := os.Getenv("NPS_ENDPOINT"); e != "" {
-		endpoint = e
-	}
+	// Validate endpoint.
+	endpoint, usedDeprecatedEndpointEnv := resolveEndpoint(data.Endpoint.ValueString())
 	if endpoint == "" {
-		resp.Diagnostics.AddError("NPS Provider configuration error", "endpoing (or NPS_ENDPOINT environment variable) must be set")
+		resp.Diagnostics.AddError("NPS Provider configuration error", "endpoint (or WORKSHOP_ENDPOINT environment variable) must be set")
 		return
+	}
+	if usedDeprecatedEndpointEnv {
+		resp.Diagnostics.AddWarning(
+			"NPS_ENDPOINT is deprecated",
+			"Set WORKSHOP_ENDPOINT instead. NPS_ENDPOINT remains a fallback for compatibility.",
+		)
 	}
 
 	// Get the necessary auth call option.
@@ -95,7 +114,7 @@ func (p *NPSProvider) Configure(ctx context.Context, req provider.ConfigureReque
 
 	// If the endpoint is localhost, allow an insecure connection.
 	// Otherwise ensure TLS is used.
-	if data.Endpoint.ValueString() == "localhost:8080" {
+	if endpoint == "localhost:8080" {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))

--- a/internal/provider/provider_endpoint_test.go
+++ b/internal/provider/provider_endpoint_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 North Pole Security, Inc.
+package provider
+
+import "testing"
+
+func TestResolveEndpointPrecedence(t *testing.T) {
+	t.Setenv("WORKSHOP_ENDPOINT", "workshop.example")
+	t.Setenv("NPS_ENDPOINT", "legacy.example")
+
+	endpoint, deprecated := resolveEndpoint("configured.example")
+	if endpoint != "configured.example" || deprecated {
+		t.Fatalf("resolveEndpoint(configured) = %q, %v", endpoint, deprecated)
+	}
+
+	endpoint, deprecated = resolveEndpoint("")
+	if endpoint != "workshop.example" || deprecated {
+		t.Fatalf("resolveEndpoint(WORKSHOP_ENDPOINT) = %q, %v", endpoint, deprecated)
+	}
+}
+
+func TestResolveEndpointDeprecatedFallback(t *testing.T) {
+	t.Setenv("WORKSHOP_ENDPOINT", "")
+	t.Setenv("NPS_ENDPOINT", "legacy.example")
+
+	endpoint, deprecated := resolveEndpoint("")
+	if endpoint != "legacy.example" || !deprecated {
+		t.Fatalf("resolveEndpoint(NPS_ENDPOINT) = %q, %v", endpoint, deprecated)
+	}
+}
+
+func TestResolveEndpointMissing(t *testing.T) {
+	t.Setenv("WORKSHOP_ENDPOINT", "")
+	t.Setenv("NPS_ENDPOINT", "")
+
+	endpoint, deprecated := resolveEndpoint("")
+	if endpoint != "" || deprecated {
+		t.Fatalf("resolveEndpoint(missing) = %q, %v", endpoint, deprecated)
+	}
+}


### PR DESCRIPTION
## Summary

Make endpoint resolution match the provider's documented configuration contract:

1. an explicit `endpoint` argument wins;
2. `WORKSHOP_ENDPOINT` is the preferred environment variable;
3. `NPS_ENDPOINT` remains a deprecated compatibility fallback.

The resolved endpoint is then used consistently for authentication, transport selection, and client creation. The provider warns when it falls back to `NPS_ENDPOINT`, and the missing-endpoint diagnostic now names the supported setting correctly.

## Concrete failure

A configuration relying on the documented environment variable could fail before this change:

```sh
export WORKSHOP_ENDPOINT=example.workshop.cloud
terraform plan
```

With no explicit `endpoint`, the provider ignored `WORKSHOP_ENDPOINT` and reported that the endpoint was missing. Separately, `NPS_ENDPOINT` could unexpectedly override an explicit provider argument, and an environment-supplied localhost endpoint could take the TLS path because transport selection inspected the unresolved provider attribute.

## Decisions

- Preserve backward compatibility by retaining `NPS_ENDPOINT` as a fallback rather than removing it.
- Make precedence explicit and deterministic: provider argument, then `WORKSHOP_ENDPOINT`, then `NPS_ENDPOINT`.
- Warn only when the deprecated fallback is actually selected.
- Use one resolved value throughout configuration so authentication, transport, and gRPC dialing cannot disagree about the endpoint.
- Keep the change scoped to endpoint resolution; API-key and token behavior are unchanged.

## Flow

```mermaid
graph LR
  A[Explicit endpoint argument] --> R[Resolved endpoint]
  B[WORKSHOP_ENDPOINT] --> R
  C[NPS_ENDPOINT compatibility fallback] --> R
  R --> D[Authentication]
  R --> E[Transport selection]
  R --> F[Client creation]
```

## Behavior

| Scenario | Before | After | Code |
|---|---|---|---|
| Explicit `endpoint` and environment variables are both set | `NPS_ENDPOINT` could override the explicit argument | The explicit argument always wins | [resolution precedence](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider.go#L69-L83), [precedence test](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider_endpoint_test.go#L6-L19) |
| Only `WORKSHOP_ENDPOINT` is set | The documented variable was ignored | The variable supplies the endpoint | [resolver](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider.go#L72-L83), [test](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider_endpoint_test.go#L15-L18) |
| Only `NPS_ENDPOINT` is set | It was accepted silently | It remains supported, with a deprecation warning | [fallback and warning](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider.go#L79-L104), [fallback test](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider_endpoint_test.go#L21-L29) |
| A localhost endpoint is supplied by the environment | Transport selection could inspect an empty provider attribute and choose TLS | Transport selection uses the resolved endpoint | [resolved transport selection](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider.go#L106-L121) |
| No endpoint source is set | The diagnostic was misspelled and referenced only the legacy variable | The diagnostic names `endpoint` and `WORKSHOP_ENDPOINT` | [diagnostic](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider.go#L93-L98), [missing-value test](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider_endpoint_test.go#L31-L39) |

The provider schema and generated documentation describe the same contract: [schema](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider.go#L53-L64), [documentation](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/docs/index.md#L52-L55).

## Validation

- Focused unit coverage for explicit configuration precedence, `WORKSHOP_ENDPOINT` precedence, deprecated fallback selection, and the missing-endpoint case: [provider endpoint tests](https://github.com/northpolesec/terraform-provider-nps/blob/d6d7ab05d4f9ca249ea5a6e172097a6b5c884bed/internal/provider/provider_endpoint_test.go#L6-L39)
- `gofmt -s -l .`
- `git diff --check`
- `go vet ./...`
- `go build ./...`
- `go test -race -count=1 ./...`

## Sequencing and conflicts

This change is self-contained and has no dependency on other provider changes. It may conflict mechanically with concurrent edits to provider schema/configuration in `internal/provider/provider.go` or regenerated `docs/index.md`; rebasing those files should be sufficient, with no behavioral sequencing requirement.
