### PR TITLE
Make directory settings destroy state-only

### DIFF
--- a/docs/resources/workshop_directory_settings.md
+++ b/docs/resources/workshop_directory_settings.md
@@ -3,12 +3,12 @@
 page_title: "nps_workshop_directory_settings Resource - nps"
 subcategory: ""
 description: |-
-  The nps_workshop_directory_settings resource manages directory settings for Workshop. This is a singleton resource — one per tenant.
+  The nps_workshop_directory_settings resource manages directory settings for Workshop. This is a singleton resource — one per tenant. Destroy removes it from Terraform state without changing Workshop.
 ---
 
 # nps_workshop_directory_settings (Resource)
 
-The `nps_workshop_directory_settings` resource manages directory settings for Workshop. This is a singleton resource — one per tenant.
+The `nps_workshop_directory_settings` resource manages directory settings for Workshop. This is a singleton resource — one per tenant. Destroy removes it from Terraform state without changing Workshop.
 
 ## Example Usage
 

--- a/internal/provider/resource_directory_settings.go
+++ b/internal/provider/resource_directory_settings.go
@@ -66,8 +66,8 @@ func (r *DirectorySettingsResource) Metadata(ctx context.Context, req resource.M
 
 func (r *DirectorySettingsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "The nps_workshop_directory_settings resource manages directory settings for Workshop. This is a singleton resource — one per tenant.",
-		MarkdownDescription: "The `nps_workshop_directory_settings` resource manages directory settings for Workshop. This is a singleton resource — one per tenant.",
+		Description:         "The nps_workshop_directory_settings resource manages directory settings for Workshop. This is a singleton resource — one per tenant. Destroy removes it from Terraform state without changing Workshop.",
+		MarkdownDescription: "The `nps_workshop_directory_settings` resource manages directory settings for Workshop. This is a singleton resource — one per tenant. Destroy removes it from Terraform state without changing Workshop.",
 
 		Attributes: map[string]schema.Attribute{
 			"directory_type": schema.StringAttribute{
@@ -227,20 +227,10 @@ func (r *DirectorySettingsResource) Update(ctx context.Context, req resource.Upd
 }
 
 func (r *DirectorySettingsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// Singleton: reset to LOCAL with no group filter
-	dirType := apipb.DirectoryType_DIRECTORY_TYPE_LOCAL
-
-	updateReq := apipb.UpdateDirectorySettingsRequest_builder{
-		Type: dirType.Enum(),
-	}.Build()
-
-	_, err := r.client.UpdateDirectorySettings(ctx, updateReq)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to reset directory settings: %v", err))
-		return
-	}
-
-	tflog.Info(ctx, "Deleted (reset) directory settings resource")
+	// Singleton settings always exist server-side. Destroying this resource is
+	// therefore state-only; resetting it to LOCAL would be a destructive and
+	// surprising tenant-wide configuration change.
+	tflog.Info(ctx, "Removed directory settings from Terraform state (server-side settings unchanged)")
 }
 
 func (r *DirectorySettingsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/resource_directory_settings_unit_test.go
+++ b/internal/provider/resource_directory_settings_unit_test.go
@@ -7,10 +7,20 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	apipb "buf.build/gen/go/northpolesec/workshop-api/protocolbuffers/go/workshop/v1"
 )
+
+func TestDirectorySettingsDeleteIsStateOnly(t *testing.T) {
+	var resp resource.DeleteResponse
+	(&DirectorySettingsResource{}).Delete(context.Background(), resource.DeleteRequest{}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("state-only delete returned diagnostics: %v", resp.Diagnostics)
+	}
+}
 
 func TestGroupsModelToProto_NullList(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Make destruction of `nps_workshop_directory_settings` a Terraform state-only operation. Directory settings are a tenant singleton that always exists server-side, so returning successfully from `Delete` now lets Terraform remove the resource from state without changing the tenant's directory type or group filter.

The resource schema and generated documentation now state this lifecycle explicitly, and a focused regression test proves that destroy succeeds without a configured API client.

## Concrete failure

Consider a tenant using directory sync with a group filter. Removing the resource from Terraform configuration, or targeting it during a state transition, previously sent an update that changed the tenant to local directory mode and removed the filter.

That was a surprising tenant-wide mutation for an object the API cannot actually delete. After this change, the same Terraform destroy removes only Terraform ownership; the existing server-side settings remain unchanged.

## Decisions

- Model the API's singleton semantics directly: there is no remote delete operation to perform.
- Make `Delete` state-only instead of translating destroy into an unrelated reset-to-local update.
- Keep intentional directory changes in `Create` and `Update`; this change affects only destroy behavior.
- Document the state-only lifecycle in both provider schema and generated resource documentation.
- Prove the absence of an RPC dependency by exercising `Delete` with no client configured.

## Flow

```mermaid
graph LR
  A[Terraform destroy] --> B[Delete callback]
  B --> C[Return success]
  C --> D[Terraform removes state]
  B --> E[No API call]
  E --> F[Workshop settings remain unchanged]
```

## Behavior

| Scenario | Before | After | Code |
|---|---|---|---|
| Destroy a managed directory-settings resource | The provider reset the tenant to local directory mode and cleared the group filter | Terraform removes the resource from state; server-side settings are unchanged | [state-only delete](https://github.com/northpolesec/terraform-provider-nps/blob/a983c4f643ebad6ef8af77b6388f6483f0d5f46d/internal/provider/resource_directory_settings.go#L229-L234) |
| Destroy while the API client is unavailable or absent | Destroy required an update RPC and could not complete safely | Destroy has no API-client dependency and returns without diagnostics | [regression test](https://github.com/northpolesec/terraform-provider-nps/blob/a983c4f643ebad6ef8af77b6388f6483f0d5f46d/internal/provider/resource_directory_settings_unit_test.go#L16-L23) |
| Review the resource lifecycle before adoption | Documentation described a managed singleton but did not explain destroy semantics | Schema and generated docs explicitly say destroy is state-only | [schema description](https://github.com/northpolesec/terraform-provider-nps/blob/a983c4f643ebad6ef8af77b6388f6483f0d5f46d/internal/provider/resource_directory_settings.go#L67-L70), [resource documentation](https://github.com/northpolesec/terraform-provider-nps/blob/a983c4f643ebad6ef8af77b6388f6483f0d5f46d/docs/resources/workshop_directory_settings.md#L5-L11) |

## Validation

- Focused state-only destroy regression: [TestDirectorySettingsDeleteIsStateOnly](https://github.com/northpolesec/terraform-provider-nps/blob/a983c4f643ebad6ef8af77b6388f6483f0d5f46d/internal/provider/resource_directory_settings_unit_test.go#L16-L23)
- `gofmt -s -l .`
- `git diff --check`
- `go vet ./...`
- `go build ./...`
- `go test -race -count=1 ./...`

## Sequencing and conflicts

This change is self-contained and has no dependency on other provider changes. It may conflict mechanically with concurrent edits to the directory-settings schema, `Delete` callback, unit-test imports, or regenerated resource documentation; no behavioral sequencing is required.
