### PR TITLE
Make the tag-order limit configurable

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,4 +53,4 @@ provider "nps" {
 
 - `api_key` (String, Sensitive) The API key to use. Can also be supplied using the `WORKSHOP_API_KEY` environment variable. If no API key is provided, the provider will attempt to use a stored short-lived user token.
 - `endpoint` (String) The base URL for the Workshop instance. Can also be supplied using the `WORKSHOP_ENDPOINT` envrionment variable.
-
+- `tag_order_max_size` (Number) Maximum number of tags accepted by `nps_workshop_tag_order`. Defaults to `25`; set this only when the Workshop tenant is configured with a different limit.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/northpolesec/terraform-provider-nps/internal/auth"
 	"google.golang.org/grpc"
@@ -37,12 +39,23 @@ type NPSProvider struct {
 
 // NPSProviderModel describes the provider data model.
 type NPSProviderModel struct {
-	Endpoint types.String `tfsdk:"endpoint"`
-	APIKey   types.String `tfsdk:"api_key"`
+	Endpoint        types.String `tfsdk:"endpoint"`
+	APIKey          types.String `tfsdk:"api_key"`
+	TagOrderMaxSize types.Int64  `tfsdk:"tag_order_max_size"`
 }
 
 type NPSProviderResourceData struct {
-	Client apipb.WorkshopServiceClient
+	Client          apipb.WorkshopServiceClient
+	TagOrderMaxSize int64
+}
+
+const defaultTagOrderMaxSize int64 = 25
+
+func configuredTagOrderMaxSize(value types.Int64) int64 {
+	if value.IsNull() || value.IsUnknown() {
+		return defaultTagOrderMaxSize
+	}
+	return value.ValueInt64()
 }
 
 func (p *NPSProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -61,6 +74,13 @@ func (p *NPSProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 				MarkdownDescription: "The API key to use. Can also be supplied using the `WORKSHOP_API_KEY` environment variable. If no API key is provided, the provider will attempt to use a stored short-lived user token.",
 				Optional:            true,
 				Sensitive:           true,
+			},
+			"tag_order_max_size": schema.Int64Attribute{
+				MarkdownDescription: "Maximum number of tags accepted by `nps_workshop_tag_order`. Defaults to `25`; set this only when the Workshop tenant is configured with a different limit.",
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
 			},
 		},
 	}
@@ -110,7 +130,8 @@ func (p *NPSProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	client := apipb.NewWorkshopServiceClient(conn)
 
 	providerData := &NPSProviderResourceData{
-		Client: client,
+		Client:          client,
+		TagOrderMaxSize: configuredTagOrderMaxSize(data.TagOrderMaxSize),
 	}
 
 	resp.DataSourceData = client

--- a/internal/provider/resource_tag_order.go
+++ b/internal/provider/resource_tag_order.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -22,14 +23,16 @@ var _ resource.Resource = &TagOrderResource{}
 var _ resource.ResourceWithConfigure = &TagOrderResource{}
 var _ resource.ResourceWithImportState = &TagOrderResource{}
 var _ resource.ResourceWithIdentity = &TagOrderResource{}
+var _ resource.ResourceWithModifyPlan = &TagOrderResource{}
 
 func NewTagOrderResource() resource.Resource {
-	return &TagOrderResource{}
+	return &TagOrderResource{maxSize: defaultTagOrderMaxSize}
 }
 
 // TagOrderResource manages the global, ordered list of enabled tags.
 type TagOrderResource struct {
-	client svcpb.WorkshopServiceClient
+	client  svcpb.WorkshopServiceClient
+	maxSize int64
 }
 
 type TagOrderIdentityModel struct {
@@ -78,10 +81,48 @@ func (r *TagOrderResource) Configure(ctx context.Context, req resource.Configure
 	}
 
 	r.client = pd.Client
+	r.maxSize = pd.TagOrderMaxSize
+}
+
+func (r *TagOrderResource) effectiveMaxSize() int64 {
+	if r.maxSize < 1 {
+		return defaultTagOrderMaxSize
+	}
+	return r.maxSize
+}
+
+func validateTagOrderSize(tags types.List, maxSize int64, diags *diag.Diagnostics) {
+	if tags.IsNull() || tags.IsUnknown() {
+		return
+	}
+	if got := int64(len(tags.Elements())); got > maxSize {
+		diags.AddAttributeError(
+			path.Root("tags"),
+			"Tag order exceeds configured maximum",
+			fmt.Sprintf("The tag order contains %d tags, but the provider's tag_order_max_size is %d.", got, maxSize),
+		)
+	}
+}
+
+func (r *TagOrderResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var data TagOrderResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	validateTagOrderSize(data.Tags, r.effectiveMaxSize(), &resp.Diagnostics)
 }
 
 // updateOrder pushes the ordered tag list from data to the server.
 func (r *TagOrderResource) updateOrder(ctx context.Context, data TagOrderResourceModel, diags *diag.Diagnostics) {
+	validateTagOrderSize(data.Tags, r.effectiveMaxSize(), diags)
+	if diags.HasError() {
+		return
+	}
 	var tags []string
 	diags.Append(data.Tags.ElementsAs(ctx, &tags, false)...)
 	if diags.HasError() {

--- a/internal/provider/resource_tag_order_unit_test.go
+++ b/internal/provider/resource_tag_order_unit_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 North Pole Security, Inc.
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func tagOrderValue(t *testing.T, count int) types.List {
+	t.Helper()
+	ctx := context.Background()
+	tags := make([]string, count)
+	for i := range tags {
+		tags[i] = fmt.Sprintf("tag-%02d", i)
+	}
+	value, diags := types.ListValueFrom(ctx, types.StringType, tags)
+	if diags.HasError() {
+		t.Fatalf("building tags list: %v", diags)
+	}
+	return value
+}
+
+func TestConfiguredTagOrderMaxSize(t *testing.T) {
+	if got := configuredTagOrderMaxSize(types.Int64Null()); got != 25 {
+		t.Fatalf("default max size = %d, want 25", got)
+	}
+	if got := configuredTagOrderMaxSize(types.Int64Value(40)); got != 40 {
+		t.Fatalf("configured max size = %d, want 40", got)
+	}
+}
+
+func TestTagOrderSizeUsesDefaultLimit(t *testing.T) {
+	var diags diag.Diagnostics
+	validateTagOrderSize(tagOrderValue(t, 26), (&TagOrderResource{}).effectiveMaxSize(), &diags)
+	if !diags.HasError() {
+		t.Fatal("expected 26 tags to exceed the default limit of 25")
+	}
+}
+
+func TestTagOrderSizeAcceptsConfiguredLimit(t *testing.T) {
+	var diags diag.Diagnostics
+	validateTagOrderSize(tagOrderValue(t, 26), 26, &diags)
+	if diags.HasError() {
+		t.Fatalf("26 tags should be accepted with tag_order_max_size=26: %v", diags)
+	}
+}


### PR DESCRIPTION
## Summary

- add a provider-level `tag_order_max_size` setting for `nps_workshop_tag_order`
- preserve a default maximum of `25` while allowing tenants with a different server limit to configure it explicitly
- validate the effective limit during planning and again immediately before the update RPC

## Concrete failure

Suppose a tenant with the standard 25-tag limit accidentally configures 26 ordered tags. Previously the provider accepted the plan and deferred the failure to the remote update. A different tenant may have a higher server-side limit and should not be constrained by a fixed client assumption.

This change makes the contract explicit: the standard case receives an attribute-scoped plan error at 26 tags, while a tenant configured for 60 tags can set `tag_order_max_size = 60` and manage its full authoritative order.

## Decisions

- Put the setting on the provider because the limit is a tenant capability shared by the singleton tag-order resource.
- Default to `25` when the value is omitted or unknown.
- Reject configured limits below one at provider-schema validation time.
- Validate in `ModifyPlan` for early feedback and in the update path so direct or programmatic resource use cannot bypass the guard.
- Leave tag uniqueness validation and authoritative ordering semantics unchanged.

## Flow

```mermaid
flowchart LR
  C["provider limit"] --> R["effective limit"]
  R --> P["plan check"]
  R --> A["apply check"]
  P --> U["tag-order update"]
  A --> U
```

## Behavior

| Scenario | Provider behavior | Code |
|---|---|---|
| `tag_order_max_size` is omitted or unknown | use the default maximum of `25` | [default resolution](https://github.com/northpolesec/terraform-provider-nps/blob/4c1f83ac42fdeb446480bfd6c16179a6a1f03bd3/internal/provider/provider.go#L52-L59) |
| A configured limit is below one | reject provider configuration | [schema validation](https://github.com/northpolesec/terraform-provider-nps/blob/4c1f83ac42fdeb446480bfd6c16179a6a1f03bd3/internal/provider/provider.go#L78-L84) |
| The planned tag list exceeds the effective limit | return an attribute-scoped plan diagnostic | [plan validation](https://github.com/northpolesec/terraform-provider-nps/blob/4c1f83ac42fdeb446480bfd6c16179a6a1f03bd3/internal/provider/resource_tag_order.go#L94-L118) |
| The update path receives an oversized list | stop before calling `UpdateTagOrder` | [pre-RPC guard](https://github.com/northpolesec/terraform-provider-nps/blob/4c1f83ac42fdeb446480bfd6c16179a6a1f03bd3/internal/provider/resource_tag_order.go#L120-L139) |
| A tenant has a higher limit | propagate the explicit value into the tag-order resource | [provider handoff](https://github.com/northpolesec/terraform-provider-nps/blob/4c1f83ac42fdeb446480bfd6c16179a6a1f03bd3/internal/provider/provider.go#L132-L139), [resource configuration](https://github.com/northpolesec/terraform-provider-nps/blob/4c1f83ac42fdeb446480bfd6c16179a6a1f03bd3/internal/provider/resource_tag_order.go#L69-L92) |

## Validation

- focused unit tests cover the default value, an explicit override, rejection above the default, and acceptance at a raised limit: [tag-order limit tests](https://github.com/northpolesec/terraform-provider-nps/blob/4c1f83ac42fdeb446480bfd6c16179a6a1f03bd3/internal/provider/resource_tag_order_unit_test.go#L27-L50)
- `gofmt -s -l .`
- `git diff --check`
- `go vet ./...`
- `go build ./...`
- `go test -race -count=1 ./...`

## Sequencing and conflicts

This change has no behavioral dependency on another change. It modifies provider configuration in `internal/provider/provider.go` and generated provider documentation in `docs/index.md`, so concurrent provider-option changes should be rebased after whichever change lands first.
