### PR TITLE
Make resource deletion idempotent

### DIFF
--- a/internal/provider/delete_helpers.go
+++ b/internal/provider/delete_helpers.go
@@ -1,0 +1,23 @@
+// Copyright 2026 North Pole Security, Inc.
+package provider
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// isDeleteNoOp reports whether a delete error means the remote object is
+// already absent.
+func isDeleteNoOp(err error) bool {
+	return status.Code(err) == codes.NotFound
+}
+
+// isRuleDeleteNoOp also accepts Workshop's terminal response for a stale rule
+// identifier after an upsert. Keep this rule-specific so unrelated resource
+// types cannot mask an InvalidArgument response that happens to share text.
+func isRuleDeleteNoOp(err error) bool {
+	return isDeleteNoOp(err) ||
+		(status.Code(err) == codes.InvalidArgument && strings.Contains(status.Convert(err).Message(), "rule is superseded"))
+}

--- a/internal/provider/delete_helpers_test.go
+++ b/internal/provider/delete_helpers_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 North Pole Security, Inc.
+package provider
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestDeleteNoOpClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		err         error
+		wantGeneric bool
+		wantRule    bool
+	}{
+		{name: "not found", err: status.Error(codes.NotFound, "gone"), wantGeneric: true, wantRule: true},
+		{name: "superseded rule", err: status.Error(codes.InvalidArgument, "invalid argument: rule is superseded"), wantRule: true},
+		{name: "unrelated invalid argument", err: status.Error(codes.InvalidArgument, "bad input")},
+		{name: "permission denied", err: status.Error(codes.PermissionDenied, "no")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDeleteNoOp(tt.err); got != tt.wantGeneric {
+				t.Fatalf("isDeleteNoOp(%v) = %v, want %v", tt.err, got, tt.wantGeneric)
+			}
+			if got := isRuleDeleteNoOp(tt.err); got != tt.wantRule {
+				t.Fatalf("isRuleDeleteNoOp(%v) = %v, want %v", tt.err, got, tt.wantRule)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_file_access_rule.go
+++ b/internal/provider/resource_file_access_rule.go
@@ -493,7 +493,7 @@ func (r *FileAccessRuleResource) Delete(ctx context.Context, req resource.Delete
 	_, err := r.client.DeleteFileAccessRule(ctx, apipb.DeleteFileAccessRuleRequest_builder{
 		RuleId: proto.Int64(ruleId),
 	}.Build())
-	if err != nil {
+	if err != nil && !isRuleDeleteNoOp(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete file access rule: %v", err))
 		return
 	}

--- a/internal/provider/resource_network_flow_rule.go
+++ b/internal/provider/resource_network_flow_rule.go
@@ -526,7 +526,7 @@ func (r *NetworkFlowRuleResource) Delete(ctx context.Context, req resource.Delet
 	_, err := r.client.DeleteNetworkFlowRule(ctx, apipb.DeleteNetworkFlowRuleRequest_builder{
 		RuleId: proto.Int64(ruleId),
 	}.Build())
-	if err != nil {
+	if err != nil && !isRuleDeleteNoOp(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete network flow rule: %v", err))
 		return
 	}

--- a/internal/provider/resource_network_flow_rule_test.go
+++ b/internal/provider/resource_network_flow_rule_test.go
@@ -2,11 +2,86 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	frameworkresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	svcpb "buf.build/gen/go/northpolesec/workshop-api/grpc/go/workshop/v1/workshopv1grpc"
+	apipb "buf.build/gen/go/northpolesec/workshop-api/protocolbuffers/go/workshop/v1"
 )
+
+type fakeNetworkFlowDeleteClient struct {
+	svcpb.WorkshopServiceClient
+	deleteErr   error
+	deleteCalls int
+}
+
+func (f *fakeNetworkFlowDeleteClient) DeleteNetworkFlowRule(ctx context.Context, in *apipb.DeleteNetworkFlowRuleRequest, _ ...grpc.CallOption) (*apipb.DeleteNetworkFlowRuleResponse, error) {
+	f.deleteCalls++
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+	return apipb.DeleteNetworkFlowRuleResponse_builder{}.Build(), nil
+}
+
+func callNetworkFlowRuleDelete(t *testing.T, r *NetworkFlowRuleResource, model NetworkFlowRuleResourceModel) *frameworkresource.DeleteResponse {
+	t.Helper()
+	ctx := context.Background()
+
+	var sResp frameworkresource.SchemaResponse
+	r.Schema(ctx, frameworkresource.SchemaRequest{}, &sResp)
+	req := frameworkresource.DeleteRequest{State: tfsdk.State{Schema: sResp.Schema}}
+	if diags := req.State.Set(ctx, model); diags.HasError() {
+		t.Fatalf("failed to build state: %v", diags)
+	}
+	resp := &frameworkresource.DeleteResponse{}
+	r.Delete(ctx, req, resp)
+	return resp
+}
+
+func testNetworkFlowRuleDeleteModel() NetworkFlowRuleResourceModel {
+	return NetworkFlowRuleResourceModel{
+		Tag:               types.StringValue("global"),
+		Name:              types.StringValue("test-rule"),
+		Action:            types.StringValue("NETWORK_FLOW_RULE_ACTION_DENY"),
+		Direction:         types.StringValue("NETWORK_FLOW_DIRECTION_OUTGOING"),
+		Priority:          types.BoolNull(),
+		Rank:              types.Int64Null(),
+		ProcessCdHashes:   types.ListNull(types.StringType),
+		ProcessSigningIds: types.ListNull(types.StringType),
+		ProcessTeamIds:    types.ListNull(types.StringType),
+		RemoteHostnames:   types.ListNull(types.StringType),
+		RemoteDomains:     types.ListNull(types.StringType),
+		RemoteAddresses:   types.ListNull(types.StringType),
+		Protocols:         types.ListNull(types.Int64Type),
+		CustomMsg:         types.StringNull(),
+		CustomUrl:         types.StringNull(),
+		Comment:           types.StringNull(),
+		Ports:             nil,
+		Id:                types.Int64Value(42),
+	}
+}
+
+func TestNetworkFlowRuleDeleteTreatsSupersededIDAsSuccess(t *testing.T) {
+	fake := &fakeNetworkFlowDeleteClient{deleteErr: status.Error(codes.InvalidArgument, "rule is superseded")}
+	r := &NetworkFlowRuleResource{client: fake}
+
+	resp := callNetworkFlowRuleDelete(t, r, testNetworkFlowRuleDeleteModel())
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("superseded ID should be an idempotent delete: %v", resp.Diagnostics)
+	}
+	if fake.deleteCalls != 1 {
+		t.Fatalf("DeleteNetworkFlowRule calls = %d, want 1", fake.deleteCalls)
+	}
+}
 
 func TestAccNetworkFlowRule(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_package_rule.go
+++ b/internal/provider/resource_package_rule.go
@@ -360,7 +360,7 @@ func (r *PackageRuleResource) Delete(ctx context.Context, req resource.DeleteReq
 	_, err := r.client.DeletePackageRule(ctx, apipb.DeletePackageRuleRequest_builder{
 		RuleId: proto.Int64(ruleId),
 	}.Build())
-	if err != nil {
+	if err != nil && !isRuleDeleteNoOp(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete package rule: %v", err))
 		return
 	}

--- a/internal/provider/resource_signal.go
+++ b/internal/provider/resource_signal.go
@@ -294,7 +294,7 @@ func (r *SignalResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		Name: proto.String(data.Name.ValueString()),
 		Tag:  proto.String(data.Tag.ValueString()),
 	}.Build())
-	if err != nil {
+	if err != nil && !isDeleteNoOp(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete signal: %v", err))
 		return
 	}

--- a/internal/provider/resource_signal_unit_test.go
+++ b/internal/provider/resource_signal_unit_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	commonpb "buf.build/gen/go/northpolesec/protos/protocolbuffers/go/common"
 	svcpb "buf.build/gen/go/northpolesec/workshop-api/grpc/go/workshop/v1/workshopv1grpc"
@@ -81,6 +83,7 @@ type fakeSignalClient struct {
 	svcpb.WorkshopServiceClient
 
 	upsertErr error
+	deleteErr error
 
 	upserted      bool
 	deleteCalls   int
@@ -98,6 +101,9 @@ func (f *fakeSignalClient) UpsertSignal(ctx context.Context, in *apipb.UpsertSig
 
 func (f *fakeSignalClient) DeleteSignal(ctx context.Context, in *apipb.DeleteSignalRequest, _ ...grpc.CallOption) (*apipb.DeleteSignalResponse, error) {
 	f.deleteCalls++
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
 	return apipb.DeleteSignalResponse_builder{}.Build(), nil
 }
 
@@ -134,6 +140,47 @@ func callSignalUpdate(t *testing.T, r *SignalResource, model SignalResourceModel
 	}
 	r.Update(ctx, req, resp)
 	return resp
+}
+
+func callSignalDelete(t *testing.T, r *SignalResource, model SignalResourceModel) *resource.DeleteResponse {
+	t.Helper()
+	ctx := context.Background()
+
+	var sResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &sResp)
+	req := resource.DeleteRequest{State: tfsdk.State{Schema: sResp.Schema}}
+	if diags := req.State.Set(ctx, model); diags.HasError() {
+		t.Fatalf("failed to build state: %v", diags)
+	}
+	resp := &resource.DeleteResponse{}
+	r.Delete(ctx, req, resp)
+	return resp
+}
+
+func TestSignalDeleteTreatsNotFoundAsSuccess(t *testing.T) {
+	fake := &fakeSignalClient{deleteErr: status.Error(codes.NotFound, "gone")}
+	r := &SignalResource{client: fake}
+
+	resp := callSignalDelete(t, r, testSignalModel())
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("NotFound should be an idempotent delete: %v", resp.Diagnostics)
+	}
+	if fake.deleteCalls != 1 {
+		t.Fatalf("DeleteSignal calls = %d, want 1", fake.deleteCalls)
+	}
+}
+
+func TestSignalDeleteDoesNotIgnoreSupersededRuleError(t *testing.T) {
+	fake := &fakeSignalClient{deleteErr: status.Error(codes.InvalidArgument, "rule is superseded")}
+	r := &SignalResource{client: fake}
+
+	resp := callSignalDelete(t, r, testSignalModel())
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("signal delete must not ignore a rule-ID-specific superseded error")
+	}
+	if fake.deleteCalls != 1 {
+		t.Fatalf("DeleteSignal calls = %d, want 1", fake.deleteCalls)
+	}
 }
 
 // TestSignalUpdateUpsertsAndNeverDeletes verifies an in-place update upserts and

--- a/internal/provider/resource_workshop_apikey.go
+++ b/internal/provider/resource_workshop_apikey.go
@@ -220,7 +220,7 @@ func (r *APIKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	_, err := r.client.DeleteAPIKey(ctx, apipb.DeleteAPIKeyRequest_builder{
 		Name: proto.String(data.Name.ValueString()),
 	}.Build())
-	if err != nil {
+	if err != nil && !isDeleteNoOp(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete API key: %v", err))
 		return
 	}

--- a/internal/provider/resource_workshop_rule.go
+++ b/internal/provider/resource_workshop_rule.go
@@ -519,7 +519,7 @@ func (r *RuleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	_, err := r.client.DeleteRule(ctx, apipb.DeleteRuleRequest_builder{
 		RuleId: proto.String(data.Id.ValueString()),
 	}.Build())
-	if err != nil {
+	if err != nil && !isRuleDeleteNoOp(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete rule: %v", err))
 		return
 	}

--- a/internal/provider/resource_workshop_tag.go
+++ b/internal/provider/resource_workshop_tag.go
@@ -465,7 +465,7 @@ func (r *TagResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	_, err := r.client.DeleteTag(ctx, apipb.DeleteTagRequest_builder{
 		Tag: proto.String(tag),
 	}.Build())
-	if err != nil {
+	if err != nil && !isDeleteNoOp(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete tag: %v", err))
 		return
 	}


### PR DESCRIPTION
## Summary

- make Terraform deletion converge when a Workshop object is already absent
- accept Workshop's narrowly defined superseded-ID terminal state only for ID-backed rule resources
- preserve diagnostics for authorization, transport, unrelated validation, and identity-inapplicable errors

## Concrete failure

Suppose an execution rule is updated through Workshop's atomic upsert path and receives a new server ID. Terraform can still hold the superseded ID during a later destroy. The delete RPC then reports `InvalidArgument: rule is superseded`; treating that terminal state as a hard failure leaves Terraform state stuck on an object that can no longer be deleted by that ID.

The same convergence problem occurs for every resource when the remote object was already removed: a `NotFound` response should let Terraform remove its local state. The exception must remain narrow, however—a signal is deleted by stable `(name, tag)` identity, so a rule-ID-specific superseded error must still surface there.

## Behavior

```mermaid
flowchart LR
    D[Delete RPC] --> N{Not found?}
    N -->|yes| C[Converged]
    N -->|no| R{Stale rule ID?}
    R -->|yes| C
    R -->|no| E[Return error]
```

| RPC result | Resource class | Provider behavior | Implementation |
|---|---|---|---|
| `NotFound` | all covered resources | treat as successful convergence | [`delete_helpers.go`](https://github.com/northpolesec/terraform-provider-nps/blob/f9e5fee277c507dc21b65505e9d28baebb25c6b0/internal/provider/delete_helpers.go#L11-L15) |
| `InvalidArgument` containing `rule is superseded` | execution, file-access, package, and network-flow rules | treat as a terminal stale-ID result | [`delete_helpers.go`](https://github.com/northpolesec/terraform-provider-nps/blob/f9e5fee277c507dc21b65505e9d28baebb25c6b0/internal/provider/delete_helpers.go#L17-L23) |
| the same superseded error | signal, API key, or tag | preserve the diagnostic | [`resource_signal.go`](https://github.com/northpolesec/terraform-provider-nps/blob/f9e5fee277c507dc21b65505e9d28baebb25c6b0/internal/provider/resource_signal.go#L293-L301) |
| permission, transport, or unrelated validation error | any resource | preserve the diagnostic | [`resource_network_flow_rule.go`](https://github.com/northpolesec/terraform-provider-nps/blob/f9e5fee277c507dc21b65505e9d28baebb25c6b0/internal/provider/resource_network_flow_rule.go#L525-L534) |

## Decisions

`NotFound` is universal because the desired post-delete state is already true. The superseded exception is separate and intentionally limited to resources deleted by mutable server-generated rule IDs. Matching both the gRPC status and the exact server message avoids turning arbitrary `InvalidArgument` failures into success.

This change covers execution rules, file-access rules, package rules, network-flow rules, signals, API keys, and tags. It does not suppress generic delete failures.

## Validation

- table-driven classification tests cover `NotFound`, superseded rule IDs, unrelated invalid arguments, and permission failures: [`delete_helpers_test.go`](https://github.com/northpolesec/terraform-provider-nps/blob/f9e5fee277c507dc21b65505e9d28baebb25c6b0/internal/provider/delete_helpers_test.go#L11-L36)
- resource-level regressions prove signal `NotFound` succeeds, a signal superseded error remains visible, and a superseded network-flow ID converges
- `gofmt -s -l .`
- `git diff --check`
- `go vet ./...`
- `go build ./...`
- `go test -race -count=1 ./...`

## Sequencing

This change is behaviorally independent. If the configurable package-child deletion change lands first, this PR will need a mechanical rebase because both changes touch `PackageRule.Delete`; that rebase must preserve both the provider-controlled cascade flag and the idempotent error handling.
